### PR TITLE
Add Portuguese translations for new quests and update existing languagues files

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/pt_br/Quests/steam_age.json
+++ b/LanguageMerger/LanguageFiles/tfg/pt_br/Quests/steam_age.json
@@ -1,0 +1,281 @@
+{
+	"quests.steam_age": "Automação Primitiva",
+	"quests.steam_age.subtitle": "De Máquinas Primitivas ao Poder do Vapor",
+
+	"quests.steam_age.basic_greate.title": "Noções Básicas de Greate",
+	"quests.steam_age.basic_greate.subtitle": "Cansado do Create? Isso vai deixar tudo mais interessante",
+	"quests.steam_age.basic_greate.desc": "Greate é uma fusão entre &3Create&r e &3GregTech&r, trazendo versões com níveis diferentes das máquinas do Create. Ele também introduz limites de estresse em Eixos e Rodas Dentadas, então você precisará planejar melhor como alimenta suas máquinas!\n\nDe forma geral, será melhor fazer montagens menores com suas próprias fontes de energia, em vez de conectar uma massa de rodas d’água em um único eixo para toda a base, como no Create tradicional.",
+
+	"quests.steam_age.create_tools.title": "Ferramentas de Trabalho",
+	"quests.steam_age.create_tools.subtitle": "Essas podem ser úteis",
+	"quests.steam_age.create_tools.desc": "Uma chave inglesa permite pegar blocos do Create rapidamente com Shift + Clique Direito, embora machados ou picaretas também funcionem. Os óculos de proteção fornecem informações detalhadas sobre suas máquinas, como o estresse que produzem ou consomem.\n\nAmbos são opcionais por enquanto, mas se mostrarão extremamente úteis e você vai querer usá-los futuramente.\n\nConsulte o capítulo de Dicas do TFG para ajuda com o sopro de vidro. Sabia que quebrar pedregulho com uma marreta vira cascalho, e quebrar o cascalho vira areia...?",
+
+	"quests.steam_age.basic_millstone.title": "Processamento Automático de Minérios",
+	"quests.steam_age.basic_millstone.subtitle": "Chega de moer na mão",
+	"quests.steam_age.basic_millstone.desc": "O &3Moinho&r é uma versão automática da Moenda. Você pode jogar os itens por cima e clicar com o botão direito para recuperar os triturados. Ele é bem lento se ligado diretamente à Manivela de Tração, mas é possível usar rodas dentadas para aumentar sua velocidade.\n\nVocê só receberá o resultado no primeiro slot. Os outros fazem parte de uma mecânica do GregTech que só será relevante bem mais tarde (&6HV&r).",
+
+	"quests.steam_age.horse_crank.title": "Sua Primeira Fonte de Energia",
+	"quests.steam_age.horse_crank.subtitle": "Hora de fazer o gado pagar o aluguel",
+	"quests.steam_age.horse_crank.desc.1": "A &3Manivela de Tração&r é sua primeira fonte viável de energia mecânica. Para usá-la, coloque a manivela no centro de uma área limpa de 7x7 blocos e prenda um animal a ela. Diferentes animais geram diferentes quantidades de energia, e os blocos sob eles afetam a velocidade da rotação. Manivelas próximas podem compartilhar parte da área de atuação.\n\nTalvez você precise segurar uma segunda corda na hora de prender o animal.",
+	"quests.steam_age.horse_crank.desc.2": "&3Animais Pequenos (4 SU):&r\nLobo, Cachorro, Porco, Ovelha, Cabra, Alpaca\n\n&3Animais Médios (6 SU):&r\nVaca, Burro\n\n&3Animais Grandes (8 SU):&r\nCavalo, Mula, Boi-Almiscarado, Iaque",
+
+	"quests.steam_age.poor_paths.title": "Caminhos Ruins",
+	"quests.steam_age.poor_paths.subtitle": "Isso é só terra mesmo",
+	"quests.steam_age.poor_paths.desc": "Esse é o pior tipo de estrada possível. A manivela vai girar a 2 RPM aqui.",
+
+	"quests.steam_age.normal_paths.title": "Caminhos Médios",
+	"quests.steam_age.normal_paths.subtitle": "Pelo menos você tentou...",
+	"quests.steam_age.normal_paths.desc": "Caminhos médios são um pouco melhores e permitem que os animais girem a manivela a 4 RPM.\n\nNota: Não é possível ter um bloco de Caminho de Terra diretamente sob a manivela, então use Cascalho nesse ponto.",
+
+	"quests.steam_age.good_paths.title": "Caminhos Bons",
+	"quests.steam_age.good_paths.subtitle": "Nem precisa de ferradura!",
+	"quests.steam_age.good_paths.desc": "Esses são os melhores caminhos disponíveis, permitindo que a manivela gire a 8 RPM. Também aumentam a velocidade de movimento do jogador, então são ótimos para pavimentar sua base!",
+
+	"quests.steam_age.helve_hammer.title": "Martinete",
+	"quests.steam_age.helve_hammer.subtitle": "CLANG... CLANG... CLANG...",
+	"quests.steam_age.helve_hammer.desc": "Está cansado de fazer placas para a Forja Catalã? O &3Martinete&r achata lingotes duplos automaticamente (mas lentamente) em placas. Você ainda terá que fazer as soldagens manualmente. Coloque uma bigorna sob o martinete, jogue os lingotes sobre ela e clique com o botão direito no martinete para pegar as placas.\n\nBigornas de nível superior exigem menos batidas para formar placas do nível anterior.",
+
+	"quests.steam_age.water_wheel.title": "Rodas D'Água",
+	"quests.steam_age.water_wheel.subtitle": "Tomara que tenha feito base perto do rio!",
+	"quests.steam_age.water_wheel.desc": "Rodas d’água geram mais energia que a Manivela de Tração, mas exigem água corrente. Você ainda não consegue mover fontes de água, então você vai precisar encontrar um rio ou cachoeira para usá-las.\n\nVocê pode obter madeira tratada embebendo tábuas em creosoto vindo do Forno de Coque.",
+
+	"quests.steam_age.windmill.title": "Moinhos de Vento",
+	"quests.steam_age.windmill.subtitle": "Combinam com tulipas",
+	"quests.steam_age.windmill.desc": "Se você não estiver perto de água corrente, moinhos de vento são uma ótima alternativa para obter energia. Quanto maior o moinho, maior a produção de estresse e velocidade.\n\nMadeira tratada pode ser obtida embebendo tábuas em creosoto do seu Forno de Coque.",
+
+	"quests.steam_age.metal_casing.title": "Invólucros Metálicos",
+	"quests.steam_age.metal_casing.subtitle": "Casco de Máquina Primitiva?",
+	"quests.steam_age.metal_casing.desc": "Esses invólucros são a base da maioria das máquinas simples que você poderá construir com o Create. Veja no JEI tudo o que dá pra criar com elas, como Caixas de Engrenagem e outros controladores de estresse.\n\nNovo no Create? Há muitos tutoriais online de construções criativas — a maioria funciona aqui no TFG também (exceto qualquer coisa que envolva geradores de pedregulho).",
+
+	"quests.steam_age.mechanical_harvester.title": "Colheitadeira Mecânica",
+	"quests.steam_age.mechanical_harvester.subtitle": "Colheita automatizada, plantio ainda não",
+	"quests.steam_age.mechanical_harvester.desc": "Com preguiça de colher e replantar suas plantações? Essas colheitadeiras fazem isso por você! Coloque-as em uma estrutura giratória e veja a mágica acontecer. Não funciona dentro de estufas.\n\nDica: sempre está a 15°C constantes ao nível da Bedrock — ideal para fazendas que funcionem o ano inteiro!",
+
+	"quests.steam_age.mechanical_saw.title": "Serra Mecânica",
+	"quests.steam_age.mechanical_saw.subtitle": "Corte eficiente de madeira, pedra... e dedos",
+	"quests.steam_age.mechanical_saw.desc": "Cansado de cortar árvores? Essas serras fazem isso por você! Basta colocá-las numa estrutura giratória. Infelizmente, o replantio ainda será manual até você obter um Implantador.\n\nEla também funciona como cortadora de pedra e é ótima para transformar toras em madeira de forma mais eficiente!",
+
+	"quests.steam_age.chute.title": "Logística Primitiva",
+	"quests.steam_age.chute.subtitle": "Infraestrutura pública para seus itens",
+	"quests.steam_age.chute.desc": "Agora você pode transportar itens! Calhas funcionam como funis mais baratos, mas só movem itens para baixo. Elas e os funis também podem empurrar itens para Tubos de Itens.\n\nFunis são similares porém melhores se usados com Correias Transportadoras do que com Tubos de Itens.",
+
+	"quests.steam_age.item_pipes.title": "Tubos de Itens",
+	"quests.steam_age.item_pipes.subtitle": "Não são tão legais quanto os Conduítes de Itens",
+	"quests.steam_age.item_pipes.desc.1": "&3Tubos de Itens&r são uma forma simples e eficaz de mover itens &dinstantaneamente&r, mas com limitações de vazão.\n\nTubos de níveis superiores oferecem uma vazão absurdamente alta — algo raro em modpacks!\n\nTubos de Itens &9não puxam&r itens, mas empurram qualquer item inserido neles para inventários conectados, priorizando &9o inventário mais próximo&r.",
+	"quests.steam_age.item_pipes.desc.2": "A mecânica de prioridade é &oum pouco complexa&r, então pule se não estiver interessado:\n\nUm &eDestino&r terá um &dValor de Roteamento&r calculado, que é a soma de todos os \"Valores de Roteamento\" dos tubos individuais até esse destino. O destino com o &cmenor &dValor de Roteamento&r será escolhido para inserção.\n\n&Tubos Restritivos&r normalmente têm a menor prioridade por possuírem um Valor de Roteamento maior.",
+	"quests.steam_age.item_pipes.desc.3": "No momento, você pode usá-los em conjunto com &6Calhas&r e &6Funis&r, mas também poderá usá-los com Módulos de Esteira, Saídas Automáticas e Máquinas com Saída Automática na era LV.\n\n&9Nota:&r Tubos no estilo do GT6 estão &dativados&r. Isso significa que, ao colocar os tubos, eles se conectam apenas ao bloco onde foram colocados. Para abrir mais conexões, use sua &5Chave Inglesa&r na grade.\n\nObtenha &equalquer&r um dos Tubos de Itens sugeridos para completar esta missão.",
+	"quests.steam_age.item_pipes.desc.4": "&l&3Curiosidade:&r&o Oooooh, ISSO! Tubos de Itens existiam no GregTech 5, e por algum motivo foram deixados de fora do GTCE, então era preciso usar outros mods para transportar itens. Quem faz isso!? Brincadeiras à parte, esperamos que aproveite os Tubos de Itens de volta no GregTech!",
+
+	"quests.steam_age.steel_greate.title": "Greate de Aço",
+	"quests.steam_age.steel_greate.subtitle": "Greate tão bom que fizeram o Greate 2",
+	"quests.steam_age.steel_greate.desc": "Bem-vindo ao próximo nível do Greate! Eixos e Rodas Dentadas de Aço aguentam quatro vezes mais estresse que os anteriores. O limite total de estresse de um sistema cinético é determinado pelo elo mais fraco, então você precisará substituir sua estrutura antiga para aproveitar os benefícios. Pelo menos algumas peças antigas podem ser recicladas!",
+
+	"quests.steam_age.steel_encased_fan.title": "Ventilador Encapsulado",
+	"quests.steam_age.steel_encased_fan.subtitle": "Perfeito para dias quentes",
+	"quests.steam_age.steel_encased_fan.desc": "O &3Ventilador Encapsulado&r é o passo final na sua primeira linha de processamento automático de minérios, eliminando a necessidade de limpar manualmente seus pós impuros. Aponte o ventilador para os pós com uma fonte de água entre eles e, em pouco tempo, estarão limpos e reluzentes. Como bônus, você ainda ganha alguns subprodutos extras! Pode ser difícil mover uma fonte de água agora, mas você pode construir ao redor de um rio ou lago existente.",
+
+	"quests.steam_age.steel_millstone.title": "Moinho de Aço",
+	"quests.steam_age.steel_millstone.subtitle": "Um upgrade que vale a pena",
+	"quests.steam_age.steel_millstone.desc": "Com uma capacidade cinética muito maior, o moinho de aço é uma atualização significativa da versão básica, permitindo uma rotação muito mais rápida e, portanto, esmagamento mais eficiente. Um ótimo upgrade para lidar com todos os novos minérios que você encontrará em breve!\n\nMais uma vez, ela só gera saída no primeiro slot no JEI.",
+
+	"quests.steam_age.steel_pump.title": "Manuseio de Fluidos",
+	"quests.steam_age.steel_pump.subtitle": "Delicioso espaquete de tubos",
+	"quests.steam_age.steel_pump.desc.1": "Com a Era do Aço, agora você pode automatizar fluidos assim como itens! A &3Bomba Mecânica&r pode extrair fluidos de praticamente qualquer coisa, incluindo barris, cadinhos e até blocos-fonte. Você pode usá-la tanto com os tubos do Create quanto com os do GregTech, embora cada um se comporte de maneira diferente.",
+	"quests.steam_age.steel_pump.desc.2": "Os tubos do Create não têm capacidade interna de fluido; em vez disso, transportam o fluido diretamente da fonte ao destino. Você pode clicar neles com um Revestimento de Cobre para \"travar\" conexões, e clicar com a chave inglesa para abrir uma janelinha que evita interseções, permitindo múltiplos tubos lado a lado. Esses tubos requerem uma bomba mecânica para funcionar, com alcance máximo de 16 blocos — mas uma única bomba pode puxar de várias fontes. Eles também não têm limite de temperatura!",
+	"quests.steam_age.steel_pump.desc.3": "Já os tubos do GregTech possuem capacidade interna e não precisam de bomba quando já há fluido dentro. Assim como os Tubos de Itens, suas conexões podem ser controladas com clique direito agachado usando a mão vazia. Recomendamos fazer isso em todos os tubos para evitar fluido indo na direção errada.\n\nSua bomba mecânica e os tubos do GregTech não estão se conectando? Gire a bomba duas vezes com a chave inglesa — isso deve resolver.",
+
+	"quests.steam_age.mold_table.title": "Automação do Alto-forno",
+	"quests.steam_age.mold_table.subtitle": "O Alto-forno Eletrico ainda está longe",
+	"quests.steam_age.mold_table.desc.1": "Você vai precisar de &3toneladas&r de aço por um bom tempo, então automatizar seu alto-forno será um ótimo investimento. A Bomba Mecânica pode puxar fluido diretamente do alto-forno (muito mais rápido do que deixar escorrer em um cadinho) para uma Mesa de Moldes, resfriando os lingotes instantaneamente! Em seguida, use uma Calha ou Funil abaixo da mesa para extrair os lingotes. A partir daí, envie o Ferro-Gusa para o Martinete.",
+	"quests.steam_age.mold_table.desc.2": "Se quiser, também pode usar uma Calha para alimentar automaticamente o alto-forno de cima, e um Implantador para operar os foles. Usar demais os foles desgasta rapidamente seu Tuyere, mas os Tubos de Itens podem inserir um novo automaticamente.\n\nVocê também pode usar uma bomba para extrair tanto do alto-forno quanto do cadinho, usando uma Válvula de Fluido para pausar a bomba enquanto estiver fazendo a liga e reativá-la depois.",
+
+	"quests.steam_age.fluid_pipes.title": "Tubos de Fluidos",
+	"quests.steam_age.fluid_pipes.subtitle": "Líquidos, gases... nós não discriminamos",
+	"quests.steam_age.fluid_pipes.desc.1": "&bTubos de Fluidos&r irão transportar &7Vapor&r entre máquinas para você.\n\nCada Tubo tem uma certa vazão descrita em mB/t e um &6Limite de Temperatura&r. Isto é relevante agora, pois o Vapor vai queimar Tubos de Madeira. Alguns tubos têm atributos &bespeciais&r que você não precisa se preocupar no momento.\n\nCada material tem vários tamanhos para os Tubos. Quanto maior o Tubo for, &amaior&r será a vazão, porém será mais &dcaro&r para fabricá-lo. Por exemplo, um &6Tubo de Fluido de Bronze&r normal transfere 120 mB/t (Ele também tem uma capacidade interna de 1200mB!)\n\nPara começar, nós recomendamos usar tubos de Madeira para fluidos frios e de Bronze para os quentes.",
+	"quests.steam_age.fluid_pipes.desc.2": "&aLembrete:&r 1 segundo = 20 tiques... supondo que o server não esteja travando.\n\n&dObservação:&r Canos estilo GT6 estão habilitados. Isso significa que posicionar Canos os conecta apenas ao bloco contra o qual foram posicionados. Para abrir mais conexões, use sua Chave Inglesa no cano.\n\nVocê também pode pressionar Shift e clicar com a Chave Inglesa para desabilitar a entrada de um lado. Isso pode ajudar a neutralizar o efeito de sloshing (líquidos viajando em uma direção indesejada).",
+
+	"quests.steam_age.fluid_drums.title": "Armazenamento Eficiente de Fluidos",
+	"quests.steam_age.fluid_drums.subtitle": "Eu acho que um barril de madeira não aguenta aço derretido",
+	"quests.steam_age.fluid_drums.desc.1": "&6TFG&r pode rapidamente ficar &4esmagador&r com a infinidade de fluidos que ele introduz, você pode estar procurando uma maneira de armazená-los.\n\nApresentando... &aTambores&r! Eles têm grandes capacidades internas e qualquer &aTambor&r pode ser quebrado e recolhido, &dmantendo o fluido&r dentro. Um clique com o botão direito do mouse com uma chave de fenda permite que um Tambor drene seu conteúdo para outro recipiente colocado abaixo dele.",
+	"quests.steam_age.fluid_drums.desc.2": "&l&3Curiosidade:&r&o Esses tambores são, na verdade, trazidos do GregTech 6.",
+
+
+	"quests.steam_age.boilers.title": "Caldeiras a Vapor",
+	"quests.steam_age.boilers.subtitle": "Sala de Vapor Portátil",
+	"quests.steam_age.boilers.desc.1": "Máquinas a vapor precisam de energia! Você tem três opções para gerar vapor: a caldeira &3Sólida&r aceita combustíveis sólidos como carvão e carvão vegetal, a caldeira &3Líquida&r aceita líquidos como creosoto e lava, e a caldeira &3Solar&r não requer combustível, funcionando apenas durante o dia. A escolha é sua, mas recomendamos a caldeira líquida se não tiver certeza.\n\nTodas as máquinas a vapor têm uma saída de ar que precisa permanecer desobstruída para que funcionem corretamente.",
+	"quests.steam_age.boilers.desc.2": "&aAviso:&r As caldeiras &bexplodirão&r se você tentar colocar água nelas enquanto estiverem secas e quentes. É melhor sempre bombear água para dentro delas, mas você sempre pode quebrar e colocar o bloco para redefinir sua temperatura.",
+	"quests.steam_age.boilers.tasks": "Qualquer Caldeira a Vapor de Alta Pressão",
+
+	"quests.steam_age.steam_bloomery.title": "Forja Catalã a Vapor",
+	"quests.steam_age.steam_bloomery.subtitle": "O tio da Forja Catalã",
+	"quests.steam_age.steam_bloomery.desc": "Você sempre vai precisar de muito Ferro Forjado, então por que não automatizar sua Forja Catalã? A maneira mais próxima de automatizar o ferro forjado está bem longe, em LV. A Forja Catalã a Vapor é um novo multibloco que automatizará sua antiga Forja Catalã do TFC, e fará isso mais rápido também! Assim como no Forno de Coque, você pode pressionar a tecla 'Usos' do JEI (o padrão é \"U\") para exibir a aba de pré-visualização de multiblocos. Clique em blocos individuais para ver o que é válido em cada local.",
+
+	"quests.steam_age.steam_furnace.title": "Fornalha a Vapor",
+	"quests.steam_age.steam_furnace.subtitle": "As fornalhas da Fornalha a Vapor...",
+	"quests.steam_age.steam_furnace.desc": "Que fundir algo rapidamente em um lingote? A &3Fornalha a Vapor&r faz exatamente isso! Ela pode transformar muitos minérios e pós rapidamente em lingotes, sem gerar subprodutos. Embora também possa cozinhar comida para você, atualmente há um bug em que a data de validade dos alimentos não é copiada corretamente, o que significa que alguns alimentos podem sair estragados. Recomendamos usar o Forno da Firmalife para isso",
+
+	"quests.steam_age.steam_oven.title": "Forno a Vapor",
+	"quests.steam_age.steam_oven.subtitle": "O irmão mais velho do Moedor a Vapor",
+	"quests.steam_age.steam_oven.desc.1": "&ou...ou irmão mais novo. Não deixe que ele saiba!&r\n\nO &3Forno a Vapor&r é uma ótima opção multibloco se você precisa &6fundir grandes quantidades de itens sem esforço.&r Chega de fileiras de fornalhas que você precisa esvaziar e reabastecer manualmente!\n\nEle se comporta efetivamente como uma fornalha paralela, fundindo até 8 itens por vez por um baixo custo de Vapor.",
+	"quests.steam_age.steam_oven.desc.2": "&l&Curiosidade:&r&o Este Multibloco - apesar de ser muito semelhante ao seu irmão, o Moedor a Vapor - não é trazido de uma versão ou complemento da GregTech. Seu verdadeiro progenitor é o Forno a Vapor do Railcraft, que remonta à versão 1.4.7!",
+
+	"quests.steam_age.steam_macerator.title": "Macerador a Vapor",
+	"quests.steam_age.steam_macerator.subtitle": "O Macerador a Vapor macera...",
+	"quests.steam_age.steam_macerator.desc": "Esta máquina faz exatamente a mesma coisa que o Moinho, então, se você já tem uma, não faz muito sentido construir esta. Ainda assim, uma ou outra é necessária para a progressão neste momento. Não, esta máquina também não gera nenhum dos slots de saída extras. Você terá que esperar até &6HV&r para isso.",
+
+	"quests.steam_age.steam_grinder.title": "Moedor a Vapor",
+	"quests.steam_age.steam_grinder.subtitle": "A irmã mais nova do Macerador a Vapor",
+	"quests.steam_age.steam_grinder.desc": "Assim como o Forno a Vapor, o &3Moedor a Vapor&r é uma versão aprimorada da versão de bloco único que pode processar vários itens ao mesmo tempo. Vale a pena? Isso depende de você.",
+
+	"quests.steam_age.rock_crusher.title": "Triturador de Pedras a Vapor",
+	"quests.steam_age.rock_crusher.subtitle": "O Triturador de Pedras duplica blocos... espera, o quê?",
+	"quests.steam_age.rock_crusher.desc": "O Triturador de Pedras é basicamente um gerador de pedregulho em uma caixa. Ele pode pegar qualquer pedra bruta ou pedregulho e gerar mais, a qualquer momento. o baixo custo de apenas um pouco de vapor. Isso não ajuda em nada no progresso, mas se você quer fazer muitos tijolos, esta máquina é perfeita.",
+
+	"quests.steam_age.forge_hammer.title": "Martelo de Forja a Vapor",
+	"quests.steam_age.forge_hammer.subtitle": "O Martelo de Forja martela...",
+	"quests.steam_age.forge_hammer.desc": "Com a criação desta máquina, muitas receitas que antes exigiam o uso de um martelo podem ser feitas aqui!\n\nEla pode processar &bPedregulho em Cascalho&r e &dCascalho em Areia&r - e é rápida, além disso.\n\nPor último, mas não menos importante, ela produz &aPlacas&r em uma proporção melhor: &6três Lingotes para duas Placas&r. Um investimento que vale a pena!\n\nAlém de tudo isso, o Martelo de Forja permite que você trabalhe (lentamente) entre lingotes, como Flores de Ferro Brutas em Ferro Forjado ou Ferro-gusa em Aço, se você quiser uma versão mais compacta do Martinete!",
+
+	"quests.steam_age.alloy_smelter.title": "Fundidor de Ligas a Vapor",
+	"quests.steam_age.alloy_smelter.subtitle": "O Fundidor de Ligas faz ligas...",
+	"quests.steam_age.alloy_smelter.desc": "O &bFundidor de Ligas&r é usado para, bem, ligas. Você vai querer usá-lo por conta da receita eficiente de &6Bronze&r, e para criar &4Liga Vermelha&r em breve.\n\nEle também pode soldar lingotes de Alto Teor de Carbono com muito mais eficiência!\n\nEntre todas as máquinas da &6Era do Vapor&r, essa é a que mais consome vapor. Se um dia você ficar sem vapor, dê um &apequeno tapinha&r com &dqualquer Martelo Macio&r para pausá-lo momentaneamente.",
+
+	"quests.steam_age.compressor.title": "Compressor a Vapor",
+	"quests.steam_age.compressor.subtitle": "O Compressor a Vapor comprime...",
+	"quests.steam_age.compressor.desc": "O &3Compressor a Vapor&r pode transformar lingotes e gemas em blocos, pepitas em lingotes, e o mais importante: polpa de madeira em Tábuas únicas. Em breve você vai entender por que isso é tão importante!",
+
+	"quests.steam_age.molding.title": "Moldagem",
+	"quests.steam_age.molding.subtitle": "Pare de pirar e comece a moldar",
+	"quests.steam_age.molding.desc": "Além de fundir metais, o Fundidor de Ligas também pode usar &3Moldes&r para converter materiais em diferentes formatos.\n\nVocê vai precisar dos moldes indicados para as futuras fundições de ligas. Certifique-se de fazer &aMoldes&r — não faça &cModelos de Extrusora&r, pois eles são usados em outra máquina.\n\nTalvez você se interesse pelos moldes de Engrenagem, mas fabricá-las com moldes sai mais caro do que fazê-las manualmente.",
+
+	"quests.steam_age.red_alloy.title": "Liga Vermelha",
+	"quests.steam_age.red_alloy.subtitle": "Uma liga completamente fictícia",
+	"quests.steam_age.red_alloy.desc": "A &4Liga Vermelha&r é uma liga de Cobre com Redstone, valorizada no universo GregTech por sua condutividade. Você pode criá-la tanto no Fundidor de Ligas quanto no seu Cadinho, se preferir.\n\nVocê vai precisar de algumas para os &9Tubos de Elétrons&r.\n\n&l&3Curiosidade:&r&o Este material surgiu originalmente no mod RedPower — uma verdadeira viagem no tempo!",
+
+	"quests.steam_age.extractor.title": "Extrator a Vapor",
+	"quests.steam_age.extractor.subtitle": "O Extrator a Vapor extrai...",
+	"quests.steam_age.extractor.desc": "Poucos itens são produzidos no &3Extrator&r durante a &6Era do Vapor&r, já que ele ainda não é capaz de extrair fluidos.",
+
+	"quests.steam_age.glass_tube.title": "Tubos de Vidro",
+	"quests.steam_age.glass_tube.subtitle": "Você vai querer vários desses",
+	"quests.steam_age.glass_tube.desc": "Embora você possa fazer todos eles manualmente com sopro de vidro, é muito mais eficiente produzi-los no Fundidor de Ligas com o molde apropriado. Precisa de bastante pó de vidro? Você pode soprar 16 painéis de uma vez para macerá-los, ou usar o Triturador de Rocha e o Martelo de Forja para obter bastante areia, e então adicionar um pouco de pó de Sílex para convertê-la em pó de vidro.",
+
+	"quests.steam_age.treated_planks.title": "Tábuas Tratadas",
+	"quests.steam_age.treated_planks.subtitle": "Também conhecido como Compensado Tratado",
+	"quests.steam_age.treated_planks.desc": "Espero que você esteja guardando seu creosoto, porque fazer essas tábuas trituradas e compactadas é outro uso para ele.\n\n&l&3Lore:&r&o Em versões anteriores do TerraFirmaGreg, este era o ponto em que você podia realmente começar no Create!",
+
+	"quests.steam_age.electron_tube.title": "Tubos de Elétrons",
+	"quests.steam_age.electron_tube.subtitle": "Ultra Ultra Baixa Voltagem...?",
+	"quests.steam_age.electron_tube.desc": "Eles podem ser muito difíceis de fabricar no início, mas você deve usar os primeiros para criar uma linha de Implantadores, para tornar sua fabricação significativamente mais barata.\n\nAlém dos Implantadores, elas também são usadas para uma grande variedade de máquinas avançadas do Create!",
+
+	"quests.steam_age.rotation_speed_controller.title": "Controlador de Velocidade de Rotação",
+	"quests.steam_age.rotation_speed_controller.subtitle": "Sem mais relações de transmissão manuais!",
+	"quests.steam_age.rotation_speed_controller.desc": "O &3Controlador de Velocidade de Rotação&r pode simplificar todo o seu espaguete de roda dentada em um único bloco, permitindo que você ajuste o RPM de forma simples e compacta. Isso será útil mais tarde, quando você tiver mais máquinas para equilibrar suas unidades de estresse!",
+
+	"quests.steam_age.mech_crafter.title": "Artesão Mecânico",
+	"quests.steam_age.mech_crafter.subtitle": "Para aquelas receitas de artesanato extragrandes",
+	"quests.steam_age.mech_crafter.desc": "Não se preocupe, elas são totalmente opcionais, mas são usadas para alguns artesanatos únicos que você pode achar muito úteis, além dos dois listados aqui.",
+
+	"quests.steam_age.crushing_wheel.title": "Rodas de Esmagamento",
+	"quests.steam_age.crushing_wheel.subtitle": "O namorado da esposa do primo do Moinho",
+	"quests.steam_age.crushing_wheel.desc": "Elas fazem exatamente a mesma coisa que as outras máquinas de trituração mencionadas anteriormente neste capítulo, mas são mais rápidas e em maior volume. São praticamente equivalentes ao Moedor a Vapor.",
+
+	"quests.steam_age.centrifuge.title": "Centrífuga Mecânica",
+	"quests.steam_age.centrifuge.subtitle": "Um Mundo Girando",
+	"quests.steam_age.centrifuge.desc": "O processamento de minério sempre será uma parte importante deste modpack, e esta máquina é outra parte (opcional) dele. Seguindo uma rota diferente de etapas de processamento de minério (confira a aba Diagrama de Processamento de Minério no JEI), você pode usar esta centrífuga para extrair alguns subprodutos extras dos seus minérios! A próxima melhoria para os seus minérios só virá com a Centrífuga Térmica LV, então se este é um investimento que vale a pena ou não, depende de você.",
+
+	"quests.steam_age.steam_engine.title": "Motor a Vapor",
+	"quests.steam_age.steam_engine.subtitle": "Hora de um verdadeiro poder de vapor",
+	"quests.steam_age.steam_engine.desc": "Rodas d'água e moinhos de vento não são mais suficientes? Não seria uma era do vapor sem uma máquina a vapor de verdade! Cada máquina a vapor pode gerar 256 SU, dando a você muito mais potência para explorar. Queimadores de Blaze podem ser criados sem sair de casa, e você pode usar um Braço Mecânico para alimentá-los automaticamente com combustível sólido ou combustível líquido em um balde (como creosoto). Gemas de Carvão, Antracito e Coque também podem ser usados para superaquecê-los.",
+
+	"quests.steam_age.deployers.title": "Implantadores",
+	"quests.steam_age.deployers.subtitle": "Linha de Montagem Primitiva",
+	"quests.steam_age.deployers.desc": "Embora você possa usar um único implantador pelo resto do seu tempo neste capítulo, nós realmente não recomendamos. Configurar uma linha de implantadores ao longo de uma esteira economizará muito tempo e sanidade, e você também não desperdiçará materiais, pois sempre poderá reutilizá-los para aprimorar sua fazenda de árvores mais tarde. Isso também tornará os tubos de elétrons significativamente mais baratos!",
+
+	"quests.steam_age.trains.title": "Trens",
+	"quests.steam_age.trains.subtitle": "Waypoints gostariam que fossem tão legal quanto esses",
+	"quests.steam_age.trains.desc": "Trens são uma opção fantástica para qualquer tipo de transporte de longa distância, seja de jogadores, itens ou fluidos! Eles também podem viajar com segurança por chunks descarregados. Não haverá nenhum tipo de teletransporte de jogadores por um bom tempo, então se você quiser montar uma rede ferroviária que abranja todo o continente, não precisa se preocupar com a possibilidade de ela ficar obsoleta.",
+
+	"quests.steam_age.wood_plank.title": "Tábuas de Madeira",
+	"quests.steam_age.wood_plank.subtitle": "Madeira Compensada Não Tratada...?",
+	"quests.steam_age.wood_plank.desc": "Elas são as mesmas que as Tábuas Tratadas adjacentes a esta missão, exceto que você pode usar qualquer madeira em vez de ter que mergulhá-las em creosoto primeiro.",
+
+	"quests.steam_age.organization.title": "Mantendo-se Organizado",
+	"quests.steam_age.organization.subtitle": "Você já está no primeiro círculo do inferno do microcrafting",
+	"quests.steam_age.organization.desc": "Com dificuldade para acompanhar todas as receitas e itens que você precisa? Aqui estão algumas opções que podem ajudar:\n\n&3Prancheta&r: Este item prático é uma lista de tarefas portátil, permitindo que você marque os itens como quiser.\n\n&3Projeto de Criação&r: Mantém o controle das receitas frequentes, permitindo que você crie lotes sem precisar encontrar a receita no JEI.\n\n&3Favoritos do JEI&r: Você pode pressionar a tecla \"Adicionar/Remover Favorito\" (padrão \"A\") ao passar o mouse sobre um item no JEI para marcá-lo. Você também pode marcar receitas inteiras pressionando esta tecla na saída!",
+
+	"quests.steam_age.resin_boards.title": "Placas Revestidas de Resina",
+	"quests.steam_age.resin_boards.subtitle": "Acho que você poderia dizer que estamos... enjoados do LáTeX?",
+	"quests.steam_age.resin_boards.desc": "Você sabia que é possível automatizar a produção de látex por meio de bombas mecânicas? Agora você sabe!",
+
+	"quests.steam_age.circuit_boards.title": "Eletrônica #2: Placas de Circuito",
+	"quests.steam_age.circuit_boards.subtitle": "O componente mais fácil para circuitos",
+	"quests.steam_age.circuit_boards.desc": "Combine essas placas de circuito de resina com alguns fios de cobre e você terá a base para seu primeiro &aCircuito&r!",
+
+	"quests.steam_age.vacuum_chamber.title": "Câmara de Vácuo",
+	"quests.steam_age.vacuum_chamber.subtitle": "Colocando o vácuo em tubos de vácuo",
+	"quests.steam_age.vacuum_chamber.desc": "Esta máquina é a etapa final na fabricação dos seus primeiros tubos de vácuo. Coloque-a sobre uma bacia, ligue-a e certifique-se de que a máquina esteja configurada para o modo de aspiração. Como bônus, esta máquina também pode soldar lingotes e placas para você, além de liquefazer cola e borracha, enquanto é aquecida por uma Forja de Carvão ou um Queimador de Blaze.",
+
+	"quests.steam_age.vacuum_tubes.title": "Eletrônica #3: Tubos de Vácuo",
+	"quests.steam_age.vacuum_tubes.subtitle": "O componente mais difícil para circuitos",
+	"quests.steam_age.vacuum_tubes.desc": "Criar Tubos de Vácuo pode fazer você questionar sua existência. Eles estão muito caros agora, mas logo ficarão mais baratos — essa é a filosofia geral do GregTech! Tubos de Vácuo também são tecnicamente seu primeiro Circuito de Ultra Baixa Voltagem (&8ULV&r)! Parabéns! A partir daqui, você pode começar a criar Circuitos de Baixa Voltagem ou passar mais tempo na Era do Vapor, criando outras máquinas com os Tubos de Vácuo que você acabou de criar.",
+
+	"quests.steam_age.resistors.title": "Eletrônica #1: Resistores",
+	"quests.steam_age.resistors.subtitle": "O componente mais... resistente... para circuitos",
+	"quests.steam_age.resistors.desc": "Resistores são componentes que serão usados para fazer seu primeiro Circuito.\n\nNão seria imprudente priorizar as receitas que usam &aFios Finos&r, pois elas economizarão mais materiais a longo prazo.\n\nOs fios podem ser caros agora, mas ficarão muito mais baratos se você fizer a &3Máquina de Enrolamento&r por enquanto ou o &3Enrolador de Fios&r em &7LV&r.",
+
+	"quests.steam_age.coiling_machine.title": "Máquina de Enrolamento",
+	"quests.steam_age.coiling_machine.subtitle": "Uma Gambiarra LV: meio Enrolador de Fios LV mais meio Dobrador LV",
+	"quests.steam_age.coiling_machine.desc": "A &3Máquina de Enrolamento&r é semelhante a um Enrolador de Fios LV, embora não tenha a opção de produzir diretamente diferentes tamanhos de fio. Ainda assim, este é um investimento muito vantajoso para tornar seus fios significativamente mais baratos.\n\nEsta máquina também pode produzir molas mais baratas!",
+
+	"quests.steam_age.curving_press.title": "Prensa Curvadora",
+	"quests.steam_age.curving_press.subtitle": "Tão nichada quanto a Extrusora LV",
+	"quests.steam_age.curving_press.desc": "A &3Prensa Curvadora&r pode fazer todas as mesmas receitas que uma Extrusora LV. Infelizmente, nenhuma delas faz muita coisa, já que a extrusora só se torna útil mesmo na Era de Média Voltagem. Ainda assim, se quiser fabricar várias pontas de ferramentas em massa, essa máquina dá conta do recado.",
+
+	"quests.steam_age.vibrating_table.title": "Mesa Vibratória",
+	"quests.steam_age.vibrating_table.subtitle": "Idêntica à Peneira LV",
+	"quests.steam_age.vibrating_table.desc": "A &3Mesa Vibratória&r pode processar minérios de gemas (incluindo carvão) de uma forma diferente, oferecendo um rendimento muito maior do que qualquer outra coisa que você tenha acesso no momento. De bônus, ela também pode processar quaisquer depósitos de cascalho que ainda tiver. Chega de garimpar com calha!",
+
+	"quests.steam_age.lathe.title": "Torno Mecânico",
+	"quests.steam_age.lathe.subtitle": "Você não vai acreditar com qual máquina LV ele se parece",
+	"quests.steam_age.lathe.desc": "O &3Torno&r pode transformar automaticamente um lingote em duas hastes, e parafusos longos em parafusos pequenos. Se você estiver fabricando muitos desses (e vai estar), essa máquina será um ótimo investimento.",
+
+	"quests.steam_age.steel_saw.title": "Serra Mecânica de Aço",
+	"quests.steam_age.steel_saw.subtitle": "Um cortador de pedras e um Cortador LV em um só!",
+	"quests.steam_age.steel_saw.desc": "É uma melhoria da sua Serra Mecânica Básica que também consegue processar algumas receitas metálicas, como transformar hastes em quatro parafusos, ou cortar blocos em placas. Essas receitas exigem um fluido para funcionar, mas por enquanto, você pode usar apenas água.",
+
+	"quests.steam_age.rolling_mill.title": "Laminador",
+	"quests.steam_age.rolling_mill.subtitle": "A outra metade do Dobrador LV",
+	"quests.steam_age.rolling_mill.desc.1": "Entre todas as máquinas da Era do Vapor que você pode fabricar, o &3Laminador&r é uma das melhores, pelo simples motivo de transformar um único lingote em uma única placa. Como bônus, ele também pode produzir chapas finas de forma mais barata do que manualmente!",
+	"quests.steam_age.rolling_mill.desc.2": "&l&3Curiosidade:&r &oEssa máquina existia nas versões antigas do TFG, mas produzia hastes em vez de placas — e sua melhor opção para fazer placas antes do Dobrador LV tinha 20% de chance de falha!&r",
+
+	"quests.steam_age.steel_mixer.title": "Misturador Mecânico de Aço",
+	"quests.steam_age.steel_mixer.subtitle": "Um Misturador LV antes do tempo",
+	"quests.steam_age.steel_mixer.desc": "O &3Misturador Mecânico de Aço&r é a outra melhor máquina da Era do Vapor que você pode fazer -- ele consegue misturar seus pós de aço colorido de forma muito mais eficiente do que o Cadinho! Também realiza diversas outras receitas, incluindo algumas com gases... melhor não pensar demais nisso.\n\nVocê pode usar tanto uma Forja de Carvão quanto um Queimador de Blaze para as receitas que exigem aquecimento, e um Braço Mecânico pode reabastecer qualquer um deles automaticamente.",
+
+	"quests.steam_age.potin.title": "Botequeiro...",
+	"quests.steam_age.potin.subtitle": "...hoje vou afogar as mágoas, quero seu melhor Potin.",
+	"quests.steam_age.potin.desc.1": "Os &dCanos de Fluido de Potin&r têm um &adesempenho altíssimo&r para o nível de material e custo. Talvez você queira produzir alguns para ajudar na logística de fluidos.\n\nPara obter &dPotin&r, comece fabricando sua forma em &ePó&r.\n\nEssa missão aceita tanto o cano pequeno quanto o normal. Qualquer um completa o objetivo.",
+	"quests.steam_age.potin.desc.2": "&l&3Curiosidade:&r&o Os &dCanos de Fluido de Potin&r foram criados originalmente no &9GT++&r, e representavam um grande salto de potência para os jogadores de um certo modpack chamado &4GT:NH&r. Queríamos compartilhar um pouco dessa alegria.\n\nNa vida real, &dPotin&r é uma liga usada em moedas, não em canos. O GTCEu está ficando mais fantasioso a cada dia...",
+
+	"quests.steam_age.miner.title": "Mineração Automática",
+	"quests.steam_age.miner.subtitle": "O fim da era dos desabamentos",
+	"quests.steam_age.miner.desc.1": "Agora você tem acesso a duas opções para minerar automaticamente seus minérios! Ambas são bem lentas, então o ideal é montá-las, manter os chunks carregados e ir fazer outra coisa, ao invés de ficar esperando.\n\nA Broca Mecânica precisa de uma engenhoca para cavar para baixo, quebrando todas as pedras no caminho. Você também pode prendê-la à frente de um trem ou carrinho para escavar túneis, se quiser.",
+	"quests.steam_age.miner.desc.2": "O Minerador a Vapor, por outro lado, quebra apenas blocos de minério e os substitui por pedregulho, deixando o terreno intacto. Ele minera minérios em um pequeno raio, o que significa que precisa ser movido com menos frequência que a broca, mas também é muito mais lento.",
+
+	"quests.steam_age.paper.title": "Papel",
+	"quests.steam_age.paper.subtitle": "Não vem da cana-de-açúcar",
+	"quests.steam_age.paper.desc": "Se ainda não fez nenhum, existem três formas diferentes de conseguir papel sem eletricidade:\n\n1) Fabrique pergaminho usando pele tratada, pedra-pomes e um ovo.\n\n2) Trance papiro.\n\n3) Produza a partir de hardwood (madeira dura), num processo bem demorado.\n\nMais tarde, você poderá transformar polpa de madeira diretamente em papel com um Banho Químico LV.",
+
+	"quests.steam_age.lv_circuit.title": "Seu primeiro circuito!",
+	"quests.steam_age.lv_circuit.subtitle": "O alvorecer de uma nova era",
+	"quests.steam_age.lv_circuit.desc": "A receita pode parecer intimidadora a princípio, mas se você passou tempo suficiente na Era do Vapor, tudo deve estar fácil de automatizar. Você vai produzir muitos desses por um tempo, mas suas próximas máquinas elétricas vão ajudar a baratear tudo — até que consiga uma Montadora de Circuitos no fim da era LV.",
+
+	"quests.steam_age.what_next.title": "E agora?",
+	"quests.steam_age.what_next.subtitle": "Você sabe... vem aí \"mais GregTech\"",
+	"quests.steam_age.what_next.desc": "Se você correu direto até aqui, sugerimos começar com máquinas como o Dobrador, Enrolador de Fios ou Misturador LV.\nCaso tenha construído as máquinas cinéticas abaixo, sugerimos a Montadora, Fornalha de Arco, Reator Químico ou o Polarizador.",
+
+	"quests.steam_age.alternator.title": "Alternadores",
+	"quests.steam_age.alternator.subtitle": "Transformando estresse em energia",
+	"quests.steam_age.alternator.desc.1": "Se você montou uma grande estrutura a vapor, provavelmente não quer desmontar tudo só para voltar a usar caldeiras e Turbinas de Vapor LV. Em vez disso, o &3Alternador&r converte a força (SU) dos motores a vapor em eletricidade. Cada motor a vapor + alternador deve gerar 1A de LV! Infelizmente, os alternadores geram energia em um sistema diferente do usado pelo GregTech, então você vai precisar de um Conversor de Energia para transformá-la em energia LV utilizável.",
+	"quests.steam_age.alternator.desc.2": "Um exemplo de motor a vapor produzindo 8 amperes de LV!\n"
+}

--- a/LanguageMerger/LanguageFiles/tfg/pt_br/Quests/stone_age.json
+++ b/LanguageMerger/LanguageFiles/tfg/pt_br/Quests/stone_age.json
@@ -99,9 +99,9 @@
     "quests.stone_age.find_rock.subtitle": "Grug. Quebra. Pedra",
     "quests.stone_age.find_rock.desc": "Ao começar sua jornada, a primeira coisa que você notará é um mundo completamente diferente. Você não pode mais quebrar árvores com as mãos, mas não se preocupe — nenhum homem das cavernas de verdade sobrevive sem suas ferramentas de pedra!\n\nEm vez de fabricar uma picareta de madeira, você pode simplesmente pegar pedras do chão. Comece coletando pelo menos 4 pedras. Você pode coletá-las quebrando ou clicando com o botão direito em pedras com a mão vazia.",
 
-    "quests.stone_age.rock_knapping.title": "Talhando Pedras",
+    "quests.stone_age.rock_knapping.title": "Lascando Pedras",
     "quests.stone_age.rock_knapping.subtitle": "Como nos velhos tempos do Paleolítico",
-    "quests.stone_age.rock_knapping.desc": "Pedras podem ser 'talhadas', o que é o processo de moldar um material bruto em uma forma utilizável batendo uma pedra contra a outra. A talha de pedra requer pelo menos duas pedras, e ao segurá-las e clicar com o botão direito no ar, você abrirá a interface de talha. Então, você pode 'lascar' uma das pedras para criar uma cabeça de ferramenta de pedra. Todos os formatos de ferramentas estão no EMI e no Guia de Campo.\n\nAs duas ferramentas mais importantes para o início da sua jornada são a faca de pedra e o machado de pedra, então tente talhar essas cabeças de ferramentas.",
+    "quests.stone_age.rock_knapping.desc": "Pedras podem ser 'lascadas', o que é o processo de moldar um material bruto em uma forma utilizável batendo uma pedra contra a outra. A lasca de pedra requer pelo menos duas pedras, e ao segurá-las e clicar com o botão direito no ar, você abrirá a interface de lascagem. Então, você pode 'lascar' uma das pedras para criar uma cabeça de ferramenta de pedra. Todos os formatos de ferramentas estão no EMI e no Guia de Campo.\n\nAs duas ferramentas mais importantes para o início da sua jornada são a Faca de Pedra e o Machado de Pedra, então tente lascar essas cabeças de ferramentas.",
 
     "quests.stone_age.find_stick.title": "Encontre Alguns Gravetos",
     "quests.stone_age.find_stick.subtitle": "Você precisa segurar essa ferramenta de algum jeito",
@@ -109,7 +109,7 @@
 
     "quests.stone_age.first_stone_tools.title": "Suas Primeiras Ferramentas",
     "quests.stone_age.first_stone_tools.subtitle": "Agora você é um macaco esperto",
-    "quests.stone_age.first_stone_tools.desc": "Ao talhar pedras em formas utilizáveis, você pode combiná-las com um graveto para criar suas primeiras ferramentas básicas. Você oficialmente entrou na Idade da Pedra!\n\nPedras são suficientes para a sobrevivência básica, mas eventualmente você vai querer criar ferramentas de metal para ter mais velocidade, durabilidade e opções. As próximas duas missões vão te ajudar a coletar os itens necessários.",
+    "quests.stone_age.first_stone_tools.desc": "Ao lascar pedras em formas utilizáveis, você pode combiná-las com um graveto para criar suas primeiras ferramentas básicas. Você oficialmente entrou na Idade da Pedra!\n\nPedras são suficientes para a sobrevivência básica, mas eventualmente você vai querer criar ferramentas de metal para ter mais velocidade, durabilidade e opções. As próximas duas missões vão te ajudar a coletar os itens necessários.",
 
     "quests.stone_age.stone_tools.title": "Ferramentas de Pedra",
     "quests.stone_age.stone_tools.subtitle": "Aparentemente bater as pedras é útil",
@@ -130,11 +130,11 @@
 
     "quests.stone_age.find_clay.title": "Fontes de Argila",
     "quests.stone_age.find_clay.subtitle": "Você vai precisar de muita",
-    "quests.stone_age.find_clay.desc": "Argila é uma parte essencial da tecnologia da Idade da Pedra! Semelhante à talha de pedras, a argila pode ser moldada em diferentes formas e então queimada em um Forno de Cova para criar uma variedade de itens. Ferramentas de pedra e cerâmica de argila serão a base da sua sobrevivência até que você aprenda a trabalhar com metais.\n\nA argila é encontrada em blocos no solo, geralmente cobertos por grama. No entanto, certos tipos de plantas conhecidas como \"Indicadores de Argila\" crescem exclusivamente sobre argila. Consulte o Guia de Campo para saber quais indicadores crescem no seu clima.",
+    "quests.stone_age.find_clay.desc": "Argila é uma parte essencial da tecnologia da Idade da Pedra! Semelhante à lasca de pedras, a argila pode ser moldada em diferentes formas e então queimada em um Forno de Cova para criar uma variedade de itens. Ferramentas de pedra e cerâmica de argila serão a base da sua sobrevivência até que você aprenda a trabalhar com metais.\n\nA argila é encontrada em blocos no solo, geralmente cobertos por grama. No entanto, certos tipos de plantas conhecidas como \"Indicadores de Argila\" crescem exclusivamente sobre argila. Consulte o Guia de Campo para saber quais indicadores crescem no seu clima.",
 
     "quests.stone_age.clay.title": "Argila",
     "quests.stone_age.clay.subtitle": "É Argila!",
-    "quests.stone_age.clay.desc": "Recolha pelo menos 25 unidades de argila. Você precisará fazer pelo menos 5 itens diferentes para progredir (veja as próximas missões). Após moldar a argila, coloque os itens em um Forno de Cova para transformá-los em cerâmica. A moldagem funciona como a talha de pedras, mas usa 5 argilas por item e a argila não é perdida caso você clique errado.",
+    "quests.stone_age.clay.desc": "Recolha pelo menos 25 unidades de argila. Você precisará fazer pelo menos 5 itens diferentes para progredir (veja as próximas missões). Após moldar a argila, coloque os itens em um Forno de Cova para transformá-los em cerâmica. A moldagem funciona como a lasca de pedras, mas usa 5 argilas por item e a argila não é perdida caso você clique errado.",
 
     "quests.stone_age.pit_kiln.title": "Forno de Cova",
     "quests.stone_age.pit_kiln.subtitle": "Está esquentando",
@@ -190,16 +190,16 @@
   
     "quests.stone_age.leather.title": "Couro",
     "quests.stone_age.leather.subtitle": "É óbvio que é mais complicado! AQUI É O TFG!!",
-    "quests.stone_age.leather.desc": "Ao serem mortos, animais selvagens deixam Couros Brutos. A pele bruta não pode ser usada diretamente como couro e precisa ser processado primeiro.\n\nO Couro, assim como Argila e Pedra, pode ser Talhado. Talhar couro permite criar coisas como Armaduras de Couro, Frascos e muito mais.\nSe você não quiser matar animais por couro, e viver em uma região tropical, pode transformar Abacaxi em Couro de Abacaxi, que é um substituto do couro.",
+    "quests.stone_age.leather.desc": "Ao serem mortos, animais selvagens deixam Couros Brutos. A pele bruta não pode ser usada diretamente como couro e precisa ser processado primeiro.\n\nO Couro, assim como Argila e Pedra, pode ser Trabalhado manualmente. Trabalhar o couro permite criar coisas como Armaduras de Couro, Cantis e muito mais.\nSe você não quiser matar animais por couro, e viver em uma região tropical, pode transformar Abacaxi em Couro de Abacaxi, que é um substituto do couro.",
   
     "quests.stone_age.leather_armor.title": "Armadura de Couro",
     "quests.stone_age.leather_armor.subtitle": "Proteção bem básica",
-    "quests.stone_age.leather_armor.desc": "A Armadura de Couro, assim como sua contraparte do Minecraft, é usada como um conjunto de armadura bem básico. Pode não proteger muito, mas te defende um pouco contra os elementos e oferece resistência OK contra dano de Corte.",
+    "quests.stone_age.leather_armor.desc": "A Armadura de Couro, assim como sua contraparte do Minecraft, é usada como um conjunto de armadura bem básico. Pode não proteger muito, mas te defende um pouco contra os elementos e oferece resistência OK contra Dano de Corte.",
   
     "quests.stone_age.mining_prep.title": "Preparações para Mineração",
     "quests.stone_age.mining_prep.subtitle": "Espero que você tenha anotado onde encontrou os indicadores de minério!",
     "quests.stone_age.mining_prep.desc.1": "Progredir além da Idade da Pedra exigirá muito metal, e pegar minérios pequenos na superfície não será suficiente. Você terá que cavar e começar a minerar.\nAssumindo que você &oanotou&r o local onde encontrou o cobre, encontre o meio aproximado dos indicadores e comece a cavar! Pode ser bem fundo, mas eventualmente você ficará rico. A próxima página mostra os equipamentos que você deve levar na sua primeira escavação!",
-    "quests.stone_age.mining_prep.desc.2": "&lPicareta&r: Bem óbvio que é necessária para quebrar pedra e extrair minério. Martelos não funcionam!\n\n&lEscadas e Tochas&r: Você precisará de uma maneira de subir e descer do buraco, e de luz para enxergar!\n\n&lVigas de Apoio e Pranchas&r: Minerar em TFG é bem mais perigoso — monstros aparecem no subsolo, e cavar sem cuidado pode causar desabamentos! A missão acima desta explica como mitigar esses perigos.\n\nAgora vá cavar seu buraco, sua topeira!",
+    "quests.stone_age.mining_prep.desc.2": "&lPicareta&r: Bem óbvio que é necessária para quebrar pedra e extrair minério. Marretas não funcionam!\n\n&lEscadas e Tochas&r: Você precisará de uma maneira de subir e descer do buraco, e de luz para enxergar!\n\n&lVigas de Apoio e Pranchas&r: Minerar no TFG é bem mais perigoso — monstros aparecem no subsolo, e cavar sem cuidado pode causar desabamentos! A missão acima desta explica como mitigar esses perigos.\n\nAgora vá cavar seu buraco, sua topeira!",
   
     "quests.stone_age.hazards.title": "Perigos da Mineração",
     "quests.stone_age.hazards.subtitle": "Achou que a superfície era difícil? Achou errado, otário!",
@@ -212,7 +212,7 @@
   
     "quests.stone_age.get_raw_rock.title": "Rocha Bruta",
     "quests.stone_age.get_raw_rock.subtitle": "Não, não é só \"Pedra\"",
-    "quests.stone_age.get_raw_rock.desc": "Para criar sua Bigorna de Cobre, você precisará tanto de uma Bigorna de Pedra básica quanto de uma Forja de Carvão. Para fazer uma Bigorna de Pedra, será necessário um bloco de rocha Ígnea Bruta.\n\nPara obter Rocha Bruta, quebre com cuidado os blocos &lao redor&r da Rocha Bruta que deseja minerar. Quando os 6 lados da Rocha Bruta estiverem expostos ao ar, ela se soltará em forma de item. Por fim, clique com o botão direito em um bloco de rocha ígnea bruta com um martelo para transformá-lo em sua Bigorna de Pedra.",
+    "quests.stone_age.get_raw_rock.desc": "Para criar sua Bigorna de Cobre, você precisará tanto de uma Bigorna de Pedra básica quanto de uma Forja de Carvão. Para fazer uma Bigorna de Pedra, será necessário um bloco de rocha Ígnea Bruta.\n\nPara obter Rocha Bruta, quebre com cuidado os blocos &lao redor&r da Rocha Bruta que deseja minerar. Quando os 6 lados da Rocha Bruta estiverem expostos ao ar, ela se soltará em forma de item. Por fim, clique com o botão direito em um bloco de rocha ígnea bruta com uma marreta para transformá-lo em sua Bigorna de Pedra.",
   
     "quests.stone_age.create_forge.title": "A Forja",
     "quests.stone_age.create_forge.subtitle": "O Fabric nem existe, aliás.",
@@ -231,16 +231,16 @@
     "quests.stone_age.crush_ore.desc": "A Moenda é apenas o primeiro passo no processamento de minérios! O processamento adequado de minérios é um sistema grande e complexo que você aprenderá com o tempo, e que pode ser usado para extrair muito mais metal utilizável e subprodutos de cada minério minerado. Por ora, vamos transformar os minérios brutos que você minerou em Minério Esmagado usando a Moenda. Só esse primeiro passo já aumenta a quantidade de mB que o minério renderá ao fundir.",
   
     "quests.stone_age.crush_crushed_ore.title": "Processamento Inicial de Minérios - Parte 2",
-    "quests.stone_age.crush_crushed_ore.subtitle": "Esmague com um martelo",
-    "quests.stone_age.crush_crushed_ore.desc": "Combine o Minério Esmagado com um martelo em uma grade de criação para transformá-lo em Pó Impuro, aumentando ainda mais sua produção em mB.\n\nPode parecer lento e tedioso por enquanto, mas logo você desbloqueará formas mais rápidas e automáticas de fazer isso!",
+    "quests.stone_age.crush_crushed_ore.subtitle": "Esmague com uma marreta",
+    "quests.stone_age.crush_crushed_ore.desc": "Combine o Minério Esmagado com uma marreta em uma grade de criação para transformá-lo em Pó Impuro, aumentando ainda mais sua produção de mB.\n\nPode parecer lento e tedioso por enquanto, mas logo você desbloqueará formas mais rápidas e automáticas de fazer isso!",
   
     "quests.stone_age.clean_dust.title": "Processamento Inicial de Minérios - Parte 3",
     "quests.stone_age.clean_dust.subtitle": "Lave esse pó sujo",
-    "quests.stone_age.clean_dust.desc": "Por fim, jogue Pó Impuro na água e deixe-o lá por alguns segundos para lavá-lo. Isso resultará em pó limpo — a forma final do seu minério. Ele pode até valer o equivalente a um lingote inteiro!",
+    "quests.stone_age.clean_dust.desc": "Por fim, jogue o Pó Impuro na água e deixe-o lá por alguns segundos para lavá-lo. Isso resultará em pó limpo — a forma final do seu minério. Ele pode até valer o equivalente a um lingote inteiro!",
   
     "quests.stone_age.flux.title": "Pedras de Fluxo",
     "quests.stone_age.flux.subtitle": "É basicamente cola para metais",
-    "quests.stone_age.flux.desc": "Fluxo é um item usado principalmente no trabalho com metais para soldar itens, embora também tenha outros usos.\nCertos tipos de rochas, como Calcário Branco, Calcário e Mármore, podem ser triturados para virar Fluxo, assim como conchas de diversos animais marinhos.",
+    "quests.stone_age.flux.desc": "Fluxo é um item usado principalmente no trabalho com metais para soldar itens, embora também tenha outros usos.\nCertos tipos de rochas, como Giz, Calcário e Mármore, podem ser triturados para virar Fluxo, assim como conchas de diversos animais marinhos.",
   
     "quests.stone_age.weld_copper_ingots.title": "Soldando Cobre",
     "quests.stone_age.weld_copper_ingots.subtitle": "Tão perto da Bigorna de Cobre",
@@ -248,6 +248,6 @@
   
     "quests.metal_age.copper_anvil.title": "Bigorna Nível 1: Cobre",
     "quests.metal_age.copper_anvil.subtitle": "E tudo isso para chegarmos até aqui!",
-    "quests.metal_age.copper_anvil.desc": "Parabéns! Você oficialmente terminou a Idade da Pedra e entrou na Era da Metalurgia! Com sua Bigorna de Cobre, o próximo passo é subir os Níveis de Bigorna. A cada novo nível desbloqueado, novas ferramentas e possibilidades se abrirão para tornar sua vida progressivamente mais fácil. Agora vá e torne-se um mestre ferreiro!"
+    "quests.metal_age.copper_anvil.desc": "Parabéns! Você oficialmente terminou a Idade da Pedra e entrou na Idade do Metal! Com sua Bigorna de Cobre, o próximo passo é subir os Níveis de Bigorna. A cada novo nível desbloqueado, novas ferramentas e possibilidades se abrirão para tornar sua vida progressivamente mais fácil. Agora vá e torne-se um mestre ferreiro!"
   
 }

--- a/LanguageMerger/LanguageFiles/tfg/pt_br/Quests/tfg.json
+++ b/LanguageMerger/LanguageFiles/tfg/pt_br/Quests/tfg.json
@@ -1,0 +1,24 @@
+{
+    "quests.tfg": "TerraFirmaGreg - Moderno",
+    "quests.tfg.subtitle": "Bem-vindo ao TerraFirmaGreg!",
+
+    "quests.tfg.welcome.title": "Bem-vindo ao TerraFirmaGreg!",
+    "quests.tfg.welcome.subtitle": "Modpack de Sobrevivência como deveria ter sido",
+    "quests.tfg.welcome.desc": "Obrigado por começar o TerraFirmaGreg Moderno!\n\nNeste modpack, você será desafiado a tomar controle de uma natureza intocada e transformá-la em uma maravilha industrial. Comece de forma humilde pegando pedras e termine viajando pelo espaço interestelar!",
+
+    "quests.tfg.create_team.title": "Como criar um time?",
+    "quests.tfg.create_team.subtitle": "Você joga com amigos?",
+    "quests.tfg.create_team.desc": "Você pode criar um time para completar missões juntos. Para isso, abra seu inventário, então no canto superior esquerdo selecione o botão onde estão desenhadas 3 pessoas coloridas; uma interface será aberta na qual você pode criar um time. Clique no botão §aCriar um time§r, então dê um nome e alguns outros parâmetros, e após criar um time com sucesso, você pode convidar outros jogadores para ele usando o botão de mais no círculo verde no canto superior direito. A partir deste ponto, suas missões serão sincronizadas e qualquer membro do time poderá completá-las. Boa sorte!",
+
+    "quests.tfg.capture_territory.title": "Como capturar território?",
+    "quests.tfg.capture_territory.subtitle": "E como carregar chunks no seu território",
+    "quests.tfg.capture_territory.desc": "Se você joga em um servidor, pode querer reivindicar seu território para que outros jogadores não possam interferir. Use a tecla Abrir Reivindicações (padrão \"Ctrl+M\") para abrir a janela, então clique com o botão esquerdo para reivindicar um chunk e com o botão direito para desfazê-lo. Há um limite para isso, então você não pode reivindicar tudo. Você pode clicar com shift-esquerdo em um chunk para forçar o carregamento (também conhecido como \"chunk load\"), e shift-direito para desfazer o carregamento. Reivindicar chunks incluirá todo o seu time, se você estiver em um.",
+
+    "quests.tfg.field_guide.title": "Informações importantes sobre missões!",
+    "quests.tfg.field_guide.subtitle": "Preciso ler mais?",
+    "quests.tfg.field_guide.desc": "As missões ainda estão em desenvolvimento, e estamos sempre trabalhando para melhorá-las! Muitas informações sobre mecânicas específicas também estão no seu Guia de Campo, acessível através da aba Livro no seu inventário.\n\nLembre-se de que tanto o JEI quanto o Guia de Campo são seus amigos, pois nem tudo será explicado através das missões.",
+
+    "quests.tfg.quest_shapes.title": "Informações sobre Formatos de Missões.",
+    "quests.tfg.quest_shapes.subtitle": "Acontece que formatos ajudam a entender essas missões.",
+    "quests.tfg.quest_shapes.desc": "&lEngrenagens&r: Missões em formato de engrenagem são as maiores em cada categoria de missão, elas representam o Início e o Fim das linhas de missão. Você pode considerá-las como grandes objetivos finais.\n\n&lCorações&r: Missões em formato de coração são &oopcionais&r, elas não são necessárias para o progresso e servem principalmente para jogadores perfeccionistas. Algumas missões opcionais podem ser um pouco bobas...\n\n&lOctógonos:&r Octógonos são marcos importantes em certas missões, eles representam marcos significativos."
+}

--- a/LanguageMerger/LanguageFiles/tfg/pt_br/blocks.json
+++ b/LanguageMerger/LanguageFiles/tfg/pt_br/blocks.json
@@ -1,4 +1,7 @@
 {
+	"block.tfg.piglin_disguise": "Disfarce de Piglin",
+	"block.tfg.piglin_disguise_block": "Disfarce de Piglin",
+
 	"block.tfg.decorative_vase.black": "Vaso Decorativo Preto",
 	"block.tfg.decorative_vase.gray": "Vaso Decorativo Cinza",
 	"block.tfg.decorative_vase.light_gray": "Vaso Decorativo Cinza Claro",
@@ -75,8 +78,8 @@
 	"block.tfg.Dolomite_support": "Suporte de Dolomita",
 	"block.tfg.chert_support_horizontal": "Suporte Horizontal de Cherte",
 	"block.tfg.chert_support": "Suporte de Cherte",
-	"block.tfg.chalk_support_horizontal": "Suporte Horizontal de Calcário Branco",
-	"block.tfg.chalk_support": "Suporte de Calcário Branco",
+	"block.tfg.chalk_support_horizontal": "Suporte Horizontal de Giz",
+	"block.tfg.chalk_support": "Suporte de Giz",
 	"block.tfg.rhyolite_support_horizontal": "Suporte Horizontal de Riolito",
 	"block.tfg.rhyolite_support": "Suporte de Riolito",
 	"block.tfg.dacite_support_horizontal": "Suporte Horizontal de Dacito",
@@ -144,5 +147,26 @@
 	"block.tfg.lunar_chorus_plant": "Planta do Coro",
 	"block.tfg.lunar_chorus_flower": "Flor do Coro",
 
-	"block.tfg.piglin_disguise_block": "Disfarce de Piglin"
+	"block.tfg.marker.moon": "A Lua",
+	"block.tfg.marker.mars": "Marte",
+	"block.tfg.marker.venus": "Vênus",
+	"block.tfg.marker.mercury": "Mercúrio",
+
+	"block.tfg.lv_aqueous_accumulator": "Acumulador Aquoso Básico",
+	"block.tfg.mv_aqueous_accumulator": "§bAcumulador Aquoso Avançado§r",
+	"block.tfg.hv_aqueous_accumulator": "§6Acumulador Aquoso Avançado II§r",
+	"block.tfg.ev_aqueous_accumulator": "§5Acumulador Aquoso Avançado III§r",
+	"block.tfg.electric_greenhouse": "Estufa Elétrica",
+	"block.tfg.lv_food_processor": "Processador de Alimentos Básico",
+	"block.tfg.mv_food_processor": "§bProcessador de Alimentos Avançado§r",
+	"block.tfg.hv_food_processor": "§6Processador de Alimentos Avançado II§r",
+	"block.tfg.ev_food_processor": "§5Processador de Alimentos Avançado III§r",
+	"block.tfg.lv_food_oven": "Forno Elétrico Básico",
+	"block.tfg.mv_food_oven": "§bForno Elétrico Avançado§r",
+	"block.tfg.hv_food_oven": "§6Forno Elétrico Avançado II§r",
+	"block.tfg.ev_food_oven": "§5Forno Elétrico Avançado III§r",
+	"block.tfg.lv_food_refrigerator": "Geladeira Básica",
+	"block.tfg.mv_food_refrigerator": "§bGeladeira Avançada",
+	"block.tfg.hv_food_refrigerator": "§6Geladeira Avançada II§r",
+	"block.tfg.ev_food_refrigerator": "§5Geladeira Avançada III§r"
 }

--- a/LanguageMerger/LanguageFiles/tfg/pt_br/materials.json
+++ b/LanguageMerger/LanguageFiles/tfg/pt_br/materials.json
@@ -19,7 +19,7 @@
     "material.tfg.phyllite": "Filito",
     "material.tfg.schist": "Schisto",
     "material.tfg.gneiss": "Gneisse",
-    "material.tfg.chalk": "Calcário Branco",
+    "material.tfg.chalk": "Giz",
 
     "material.tfg.moon_stone": "Anortosito",
     "material.tfg.moon_deepslate": "Norito",

--- a/LanguageMerger/LanguageFiles/tfg/pt_br/other.json
+++ b/LanguageMerger/LanguageFiles/tfg/pt_br/other.json
@@ -1,5 +1,6 @@
 {
     "tfg.disabled_portal": "A magia do portal parece estar bloqueada por uma força desconhecida, tente alcançar outra dimensão descendo ou subindo",
+    "tfg.tooltip.food_trait.refrigerating": "§9Refrigeração",
 
     "item.treetap.tap": "Item Descontinuado, Crie para Atualizar",
 
@@ -112,7 +113,7 @@
     "trim_material.tfc.salt_tfc": "Sal",
     "trim_material.tfc.sapphire_tfc": "Safira",
     "trim_material.tfc.sodalite_tfc": "Sodalita",
-    "trim_material.tfc.coke_tfc": "Coke",
+    "trim_material.tfc.coke_tfc": "Coque",
     "trim_material.tfc.spessartine_tfc": "Espessartita",
     "trim_material.tfc.topaz_tfc": "Topázio",
     "trim_material.tfc.uvarovite_tfc": "Uvarovita",


### PR DESCRIPTION
- Added new quest translations for the "steam_age" chapter (Steam Age).
- Introduced a new tooltip for the "refrigerating" food trait in the language file.
- Updated the translation of "coke" to "coque" for accurate terminology.
- Changed the translation of "chalk" from "Calcário Branco" to "Giz" for simplicity and clarity.
- Added translation to file with introductory TFG quests and presentation, including key gameplay information and mechanics.