### PR TITLE
Add Portuguese translations for various ores in the OresToFieldGuide

### DIFF
--- a/OresToFieldGuide/data/dimensions/earth.json
+++ b/OresToFieldGuide/data/dimensions/earth.json
@@ -6,6 +6,7 @@
 	"vein_tag": "tfc:in_biome/veins",
 	"translations": {
 		"en_us": "Earth",
+		"pt_br": "Terra",
 		"uk_ua": "земля"
 	}
 }

--- a/OresToFieldGuide/data/dimensions/moon.json
+++ b/OresToFieldGuide/data/dimensions/moon.json
@@ -5,6 +5,7 @@
 	"vein_index_icon": "gtceu:moon_stone_certus_quartz_ore",
 	"vein_tag": "tfg:moon_veins",
 	"translations": {
-		"en_us": "The Moon"
+		"en_us": "The Moon",
+		"pt_br": "A Lua"
 	}
 }

--- a/OresToFieldGuide/data/dimensions/nether.json
+++ b/OresToFieldGuide/data/dimensions/nether.json
@@ -6,6 +6,7 @@
 	"vein_tag": "tfg:nether_veins",
 	"translations": {
 		"en_us": "The Beneath",
+		"pt_br": "As Profundezas",
 		"uk_ua": "__"
 	}
 }

--- a/OresToFieldGuide/data/language_tokens/pt_br.json
+++ b/OresToFieldGuide/data/language_tokens/pt_br.json
@@ -1,0 +1,30 @@
+{
+	"rarity": "Raridade",
+	"density": "Densidade",
+	"type": "Tipo",
+	"y": "Y",
+	"size": "Tamanho",
+	"height": "Altura",
+	"radius": "Raio",
+	"stone_types": "Tipos de Pedra",
+	"indicator_depth": "Profundidade Máxima do Indicador",
+	"percentage": "Porcentagem",
+	"formula": "Fórmula",
+
+	"hazard": "Perigo",
+	"arsenicosis": "$(t:Requer Máscara Facial)Arsenicose (Inalação)$(/t)",
+	"asbestosis": "$(t:Requer Máscara Facial)Asbestose (Inalação)$(/t)",
+	"berylliosis": "$(t:Requer Luvas de Borracha)Beriliose (Contato com a Pele)$(/t)",
+	"carcinogenic": "$(t:Requer Proteção Completa)Carcinogênico (Qualquer Contato)$(/t)",
+	"weak_poison": "$(t:Requer Máscara Facial)Pouco Venenoso (Inalação)$(/t)",
+	"irritant": "$(t:Requer Luvas de Borracha)Irritante (Contato com a Pele)$(/t)",
+
+	"tfc:cluster_vein": "Veio Aglomerado",
+	"tfc:pipe_vein": "Veio Tubular",
+	"tfc:disc_vein": "Veio em Disco",
+
+	"vein_index": "Índice de Veios",
+	"ore_index": "Índice de Minérios",
+	"ore_index_format": "Este é o $(thing)Índice de Minérios$() para $(thing){0}$(). Todos os minérios estão ordenados alfabeticamente e do veio mais rico para o mais pobre. Você pode clicar neles para saber mais sobre cada veio.",
+	"vein_index_format": "Este é o $(thing)Índice de Veios$() para $(item){0}$(). Cada veio contém detalhes sobre sua raridade, densidade, tipo de veio, altura onde é encontrado, tamanhos, tipos de rocha em que aparece e mais."
+}

--- a/OresToFieldGuide/data/ores/almandine.json
+++ b/OresToFieldGuide/data/ores/almandine.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Almandina",
+      "info": "$(thing)Fonte de$(): Alumínio, Ferro"
+    },
+    {
       "lang": "ru_ru",
       "text": "Альмандин",
       "info": "$(thing)Хромит$(): Алюминий, Железо"

--- a/OresToFieldGuide/data/ores/aluminium.json
+++ b/OresToFieldGuide/data/ores/aluminium.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Alumínio",
+      "info": "$(thing)Fonte de$(): Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Алюминий",
       "info": "$(thing)Хромит$(): Алюминий"

--- a/OresToFieldGuide/data/ores/alunite.json
+++ b/OresToFieldGuide/data/ores/alunite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Potassium, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Alunita",
+      "info": "$(thing)Fonte de$(): Potássio, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Алунит",
       "info": "$(thing)Хромит$(): Калий, Алюминий"

--- a/OresToFieldGuide/data/ores/amethyst.json
+++ b/OresToFieldGuide/data/ores/amethyst.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Ametista",
+      "info": "$(thing)Fonte de$(): Ferro"
+    },
+    {
       "lang": "ru_ru",
       "text": "Аметист",
       "info": "$(thing)Хромит$(): Железо"

--- a/OresToFieldGuide/data/ores/anthracite.json
+++ b/OresToFieldGuide/data/ores/anthracite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Used for$(): Fuel"
         },
         {
+            "lang": "pt_br",
+            "text": "Antracito",
+            "info": "$(thing)Usado para$(): Combustível"
+        },
+        {
             "lang": "ru_ru",
             "text": "Антрацит",
             "info": "$(thing)Используется для$(): топливо"

--- a/OresToFieldGuide/data/ores/apatite.json
+++ b/OresToFieldGuide/data/ores/apatite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Calcium, Phosphorus, Forestry PTSD"
     },
     {
+      "lang": "pt_br",
+      "text": "Apatita",
+      "info": "$(thing)Fonte de$(): Cálcio, Fósforo, TEPT Florestal"
+    },
+    {
       "lang": "ru_ru",
       "text": "Апатит",
       "info": "$(thing)Хромит$(): Кальций, Фосфор"

--- a/OresToFieldGuide/data/ores/armalcolite.json
+++ b/OresToFieldGuide/data/ores/armalcolite.json
@@ -11,7 +11,7 @@
 		},
 		{
 			"lang": "pt_br",
-			"text": "Armacolita",
+			"text": "Armalcolita",
 			"info": "$(thing)Fonte de$(): Magnésio, Rutilo, Titânio"
 		}
 	]

--- a/OresToFieldGuide/data/ores/armalcolite.json
+++ b/OresToFieldGuide/data/ores/armalcolite.json
@@ -8,6 +8,11 @@
 			"lang": "en_us",
 			"text": "Armalcolite",
 			"info": "$(thing)Source of$(): Magnesium, Rutile, Titanium"
+		},
+		{
+			"lang": "pt_br",
+			"text": "Armacolita",
+			"info": "$(thing)Fonte de$(): Magnésio, Rutilo, Titânio"
 		}
 	]
 }

--- a/OresToFieldGuide/data/ores/asbestos.json
+++ b/OresToFieldGuide/data/ores/asbestos.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Source of$(): Magnesium, Lung cancer"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Amianto",
+			"info": "$(thing)Fonte de$(): Magnésio, Câncer de pulmão"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Асбест",
 			"info": "$(thing)Хромит$(): Магний"

--- a/OresToFieldGuide/data/ores/barite.json
+++ b/OresToFieldGuide/data/ores/barite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Barium"
     },
     {
+      "lang": "pt_br",
+      "text": "Barita",
+      "info": "$(thing)Fonte de$(): Bário"
+    },
+    {
       "lang": "ru_ru",
       "text": "Барит",
       "info": "$(thing)Хромит$(): Барий"

--- a/OresToFieldGuide/data/ores/basaltic_mineral_sand.json
+++ b/OresToFieldGuide/data/ores/basaltic_mineral_sand.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Cast Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Areia Mineral Basáltica",
+      "info": "$(thing)Derrete em$(): Ferro Fundido"
+    },
+    {
       "lang": "ru_ru",
       "text": "Базальтовый минеральный песок",
       "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/bastnasite.json
+++ b/OresToFieldGuide/data/ores/bastnasite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Cerium, Fluorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Bastnasita",
+      "info": "$(thing)Fonte de$(): Cério, Flúor"
+    },
+    {
       "lang": "ru_ru",
       "text": "Бастнезит",
       "info": "$(thing)Хромит$(): Церий, Фтор"

--- a/OresToFieldGuide/data/ores/bauxite.json
+++ b/OresToFieldGuide/data/ores/bauxite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Bauxita",
+      "info": "$(thing)Fonte de$(): Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Боксит",
       "info": "$(thing)Хромит$(): Алюминий"

--- a/OresToFieldGuide/data/ores/bentonite.json
+++ b/OresToFieldGuide/data/ores/bentonite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Sodium, Magnesium"
     },
     {
+      "lang": "pt_br",
+      "text": "Bentonita",
+      "info": "$(thing)Fonte de$(): Sódio, Magnésio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Бентонит",
       "info": "$(thing)Хромит$(): Натрий, Магний"

--- a/OresToFieldGuide/data/ores/beryllium.json
+++ b/OresToFieldGuide/data/ores/beryllium.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Source of$(): Beryllium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Berílio",
+			"info": "$(thing)Fonte de$(): Berílio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Бериллий",
 			"info": "$(thing)Используется для$(): Эндер-жемчуг"

--- a/OresToFieldGuide/data/ores/bismuth.json
+++ b/OresToFieldGuide/data/ores/bismuth.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Bismuth"
         },
         {
+            "lang": "pt_br",
+            "text": "Bismuto",
+            "info": "$(thing)Derrete em$(): Bismuto"
+        },
+        {
             "lang": "ru_ru",
             "text": "Висмут",
             "info": "$(thing)Плавится в$(): Висмут"

--- a/OresToFieldGuide/data/ores/blue_topaz.json
+++ b/OresToFieldGuide/data/ores/blue_topaz.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Fluorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Topázio Azul",
+      "info": "$(thing)Fonte de$(): Alumínio, Flúor"
+    },
+    {
       "lang": "ru_ru",
       "text": "Синий топаз",
       "info": "$(thing)Хромит$(): Алюминий, Фтор"

--- a/OresToFieldGuide/data/ores/borax.json
+++ b/OresToFieldGuide/data/ores/borax.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Sodium, Boron"
     },
     {
+      "lang": "pt_br",
+      "text": "Bórax",
+      "info": "$(thing)Fonte de$(): Sódio, Boro"
+    },
+    {
       "lang": "ru_ru",
       "text": "Бура",
       "info": "$(thing)Хромит$(): Натрий, Бор"

--- a/OresToFieldGuide/data/ores/bornite.json
+++ b/OresToFieldGuide/data/ores/bornite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Copper"
     },
     {
+      "lang": "pt_br",
+      "text": "Bornita",
+      "info": "$(thing)Derrete em$(): Cobre"
+    },
+    {
       "lang": "ru_ru",
       "text": "Борнит",
       "info": "$(thing)Хромит$(): Медь"

--- a/OresToFieldGuide/data/ores/calcite.json
+++ b/OresToFieldGuide/data/ores/calcite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Calcium"
     },
     {
+      "lang": "pt_br",
+      "text": "Calcita",
+      "info": "$(thing)Fonte de$(): Cálcio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Кальцит",
       "info": "$(thing)Хромит$(): Кальций"

--- a/OresToFieldGuide/data/ores/calorite.json
+++ b/OresToFieldGuide/data/ores/calorite.json
@@ -8,6 +8,11 @@
             "lang": "en_us",
             "text": "Calorite",
             "info": "$(thing)Source of$(): "
+        },
+        {
+            "lang": "pt_br",
+            "text": "Calorita",
+            "info": "$(thing)Fonte de$(): "
         }
     ]
 }

--- a/OresToFieldGuide/data/ores/cassiterite.json
+++ b/OresToFieldGuide/data/ores/cassiterite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Tin"
         },
         {
+            "lang": "pt_br",
+            "text": "Cassiterita",
+            "info": "$(thing)Derrete em$(): Estanho"
+        },
+        {
             "lang": "ru_ru",
             "text": "Касситерит",
             "info": "$(thing)Плавится в$(): Олово"

--- a/OresToFieldGuide/data/ores/cassiterite_sand.json
+++ b/OresToFieldGuide/data/ores/cassiterite_sand.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Tin"
         },
         {
+            "lang": "pt_br",
+            "text": "Areia Cassiterita",
+            "info": "$(thing)Derrete em$(): Estanho"
+        },
+        {
             "lang": "ru_ru",
             "text": "Касситеритовый песок",
             "info": "$(thing)Плавится в$(): Олово"

--- a/OresToFieldGuide/data/ores/certus_quartz.json
+++ b/OresToFieldGuide/data/ores/certus_quartz.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): Applied Energistics 2"
     },
     {
+      "lang": "pt_br",
+      "text": "Quartzo Certus",
+      "info": "$(thing)Usado para$(): Applied Energistics 2"
+    },
+    {
       "lang": "ru_ru",
       "text": "Истинный кварц",
       "info": "$(thing)Используется для$(): рецепты Applied Energistics 2"

--- a/OresToFieldGuide/data/ores/chalcocite.json
+++ b/OresToFieldGuide/data/ores/chalcocite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Copper"
     },
     {
+      "lang": "pt_br",
+      "text": "Calcocita",
+      "info": "$(thing)Fonte de$(): Cobre"
+    },
+    {
       "lang": "ru_ru",
       "text": "Халькозин",
       "info": "$(thing)Хромит$(): Медь"

--- a/OresToFieldGuide/data/ores/chalcopyrite.json
+++ b/OresToFieldGuide/data/ores/chalcopyrite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Copper"
     },
     {
+      "lang": "pt_br",
+      "text": "Calcopirita",
+      "info": "$(thing)Derrete em$(): Cobre"
+    },
+    {
       "lang": "ru_ru",
       "text": "Халькопирит",
       "info": "$(thing)Плавится в$(): Медь"

--- a/OresToFieldGuide/data/ores/chromite.json
+++ b/OresToFieldGuide/data/ores/chromite.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Source of$(): Chromium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cromita",
+			"info": "$(thing)Fonte de$(): Cromo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Хромит",
 			"info": "$(thing)Хромит$(): Хром"

--- a/OresToFieldGuide/data/ores/cinnabar.json
+++ b/OresToFieldGuide/data/ores/cinnabar.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Mercury"
     },
     {
+      "lang": "pt_br",
+      "text": "Cinábrio",
+      "info": "$(thing)Fonte de$(): Mercúrio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Киноварь",
       "info": "$(thing)Хромит$(): Ртуть"

--- a/OresToFieldGuide/data/ores/coal.json
+++ b/OresToFieldGuide/data/ores/coal.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): Fuel, Distillation"
     },
     {
+      "lang": "pt_br",
+      "text": "Carvão",
+      "info": "$(thing)Usado para$(): Combustível, Destilação"
+    },
+    {
       "lang": "ru_ru",
       "text": "Уголь",
       "info": "$(thing)Используется для$(): топливо, ректификация"

--- a/OresToFieldGuide/data/ores/cobalt.json
+++ b/OresToFieldGuide/data/ores/cobalt.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Smelts into$(): Cobalt"
     },
     {
+      "lang": "pt_br",
+      "text": "Cobalto",
+      "info": "$(thing)Derrete em$(): Cobalto"
+    },
+    {
       "lang": "ru_ru",
       "text": "Кобальт",
       "info": "$(thing)Плавится в$(): Кобальт"

--- a/OresToFieldGuide/data/ores/cobaltite.json
+++ b/OresToFieldGuide/data/ores/cobaltite.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Source of$(): Cobalt, Arsenic"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cobaltita",
+			"info": "$(thing)Fonte de$(): Cobalto, Arsênico"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Кобальтит",
 			"info": "$(thing)Хромит$(): Кобальт, Мышьяк"

--- a/OresToFieldGuide/data/ores/cooperite.json
+++ b/OresToFieldGuide/data/ores/cooperite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Platinum, Nickel, Palladium"
     },
     {
+      "lang": "pt_br",
+      "text": "Cooperita",
+      "info": "$(thing)Fonte de$(): Platina, Níquel, Paládio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Шелдонит",
       "info": "$(thing)Хромит$(): Платина, Никель, Палладий"

--- a/OresToFieldGuide/data/ores/copper.json
+++ b/OresToFieldGuide/data/ores/copper.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Copper"
         },
         {
+            "lang": "pt_br",
+            "text": "Cobre Nativo",
+            "info": "$(thing)Derrete em$(): Cobre"
+        },
+        {
             "lang": "ru_ru",
             "text": "Самородная Медь",
             "info": "$(thing)Плавится в$(): Медь"

--- a/OresToFieldGuide/data/ores/desh.json
+++ b/OresToFieldGuide/data/ores/desh.json
@@ -8,6 +8,11 @@
 			"lang": "en_us",
 			"text": "Desh",
 			"info": "$(thing)Source of$(): Iron, Titanium, Nitrogen"
+		},
+		{
+			"lang": "pt_br",
+			"text": "Desh",
+			"info": "$(thing)Fonte de$(): Ferro, Titânio, Nitrogênio"
 		}
 	]
 }

--- a/OresToFieldGuide/data/ores/diamond.json
+++ b/OresToFieldGuide/data/ores/diamond.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): Macerators, AE2"
     },
     {
+      "lang": "pt_br",
+      "text": "Diamante",
+      "info": "$(thing)Usado para$(): Maceradores, AE2"
+    },
+    {
       "lang": "ru_ru",
       "text": "Алмаз",
       "info": "$(thing)Используется для$(): Измельчители, предметы из AE2"

--- a/OresToFieldGuide/data/ores/diatomite.json
+++ b/OresToFieldGuide/data/ores/diatomite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Iron, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Diatomita",
+      "info": "$(thing)Fonte de$(): Ferro, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Диатомовый пелит",
       "info": "$(thing)Хромит$(): Железо, Алюминий"

--- a/OresToFieldGuide/data/ores/diopside.json
+++ b/OresToFieldGuide/data/ores/diopside.json
@@ -8,6 +8,11 @@
 			"lang": "en_us",
 			"text": "Diopside",
 			"info": "$(thing)Source of$(): Magnesium, Calcium"
+		},
+		{
+			"lang": "pt_br",
+			"text": "Diopsídio",
+			"info": "$(thing)Fonte de$(): Magnésio, Cálcio"
 		}
 	]
 }

--- a/OresToFieldGuide/data/ores/electrotine.json
+++ b/OresToFieldGuide/data/ores/electrotine.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Gold, Silver, Redstone"
     },
     {
+      "lang": "pt_br",
+      "text": "Eletrotina",
+      "info": "$(thing)Fonte de$(): Ouro, Prata, Redstone"
+    },
+    {
       "lang": "ru_ru",
       "text": "Электротин",
       "info": "$(thing)Хромит$(): Золото, Серебро, Редстоун"

--- a/OresToFieldGuide/data/ores/emerald.json
+++ b/OresToFieldGuide/data/ores/emerald.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): MV components, Item tag filters"
     },
     {
+      "lang": "pt_br",
+      "text": "Esmeralda",
+      "info": "$(thing)Usado para$(): Components MV, Filtros de Tag de Item"
+    },
+    {
       "lang": "ru_ru",
       "text": "Изумруд",
       "info": "$(thing)Используется для$(): компоненты уровня MV, Предметные фильтры (Тэг)"

--- a/OresToFieldGuide/data/ores/enstatite.json
+++ b/OresToFieldGuide/data/ores/enstatite.json
@@ -9,5 +9,10 @@
 			"text": "Enstatite",
 			"info": "$(thing)Source of$(): Magnesium"
 		}
+		{
+			"lang": "pt_br",
+			"text": "Enstatita",
+			"info": "$(thing)Fonte de$(): Magnésio"
+		}
 	]
 }

--- a/OresToFieldGuide/data/ores/etrium.json
+++ b/OresToFieldGuide/data/ores/etrium.json
@@ -7,7 +7,7 @@
 		{
 			"lang": "en_us",
 			"text": "Etrium",
-			"info": "$(thing)Source of$(): "
+			"info": "$(thing)Fonte de$(): "
 		}
 	]
 }

--- a/OresToFieldGuide/data/ores/etrium.json
+++ b/OresToFieldGuide/data/ores/etrium.json
@@ -7,6 +7,11 @@
 		{
 			"lang": "en_us",
 			"text": "Etrium",
+			"info": "$(thing)Source of$(): "
+		},
+		{
+			"lang": "pt_br",
+			"text": "Etrium",
 			"info": "$(thing)Fonte de$(): "
 		}
 	]

--- a/OresToFieldGuide/data/ores/fayalite.json
+++ b/OresToFieldGuide/data/ores/fayalite.json
@@ -8,6 +8,11 @@
 			"lang": "en_us",
 			"text": "Fayalite",
 			"info": "$(thing)Smelts into$(): Iron"
+		},
+		{
+			"lang": "pt_br",
+			"text": "Faialite",
+			"info": "$(thing)Derrete em$(): Ferro"
 		}
 	]
 }

--- a/OresToFieldGuide/data/ores/fullers_earth.json
+++ b/OresToFieldGuide/data/ores/fullers_earth.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Magnesium"
     },
     {
+      "lang": "pt_br",
+      "text": "Terra de Fuller",
+      "info": "$(thing)Fonte de$(): Magnésio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Смектическая глина",
       "info": "$(thing)Хромит$(): Магний"

--- a/OresToFieldGuide/data/ores/galena.json
+++ b/OresToFieldGuide/data/ores/galena.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Smelts into$(): Lead"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Galena",
+			"info": "$(thing)Derrete em$(): Chumbo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Галена",
 			"info": "$(thing)Плавится в$(): Свинец"

--- a/OresToFieldGuide/data/ores/garnet_sand.json
+++ b/OresToFieldGuide/data/ores/garnet_sand.json
@@ -9,6 +9,11 @@
       "info": "$(thing)Source of$(): Almandine, Andradite, Grossular, Pyrope, Spessartine, Uvarovite"
     },
     {
+      "lang": "pt_br",
+      "text": "Areia Granada",
+      "info": "$(thing)Fonte de$(): Almandina, Andradita, Glossulária, Piropo, Espessartita, Uvarovita"
+    },
+    {
       "lang": "ru_ru",
       "text": "Гранатовый песок",
       "info": "$(thing)Хромит$(): Альмандин, Андрадит, Гроссуляр, Пироп, Спасерит, Уваровит"

--- a/OresToFieldGuide/data/ores/garnierite.json
+++ b/OresToFieldGuide/data/ores/garnierite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Nickel"
         },
         {
+            "lang": "pt_br",
+            "text": "Garnierita",
+            "info": "$(thing)Derrete em$(): Níquel"
+        },
+        {
             "lang": "ru_ru",
             "text": "Гарниерит",
             "info": "$(thing)Плавится в$(): Никель"

--- a/OresToFieldGuide/data/ores/glauconite_sand.json
+++ b/OresToFieldGuide/data/ores/glauconite_sand.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Magnesium, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Areia Glauconita",
+      "info": "$(thing)Fonte de$(): Magnésio, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Глауконитовый песок",
       "info": "$(thing)Хромит$(): Магний, Алюминий"

--- a/OresToFieldGuide/data/ores/goethite.json
+++ b/OresToFieldGuide/data/ores/goethite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Cast Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Goethita",
+      "info": "$(thing)Derrete em$(): Ferro Fundido"
+    },
+    {
       "lang": "ru_ru",
       "text": "Гётит",
       "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/gold.json
+++ b/OresToFieldGuide/data/ores/gold.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Gold"
         },
         {
+            "lang": "pt_br",
+            "text": "Ouro Nativo",
+            "info": "$(thing)Derrete em$(): Ouro"
+        },
+        {
             "lang": "ru_ru",
             "text": "Самородная Золото",
             "info": "$(thing)Плавится в$(): Золото"

--- a/OresToFieldGuide/data/ores/granitic_mineral_sand.json
+++ b/OresToFieldGuide/data/ores/granitic_mineral_sand.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Cast Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Areia Mineral Granítica",
+      "info": "$(thing)Derrete em$(): Ferro Fundido"
+    },
+    {
       "lang": "ru_ru",
       "text": "Гранитовый минеральный песок",
       "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/graphite.json
+++ b/OresToFieldGuide/data/ores/graphite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): $(l:mechanics/fire_clay)Fire Clay$(), Graphene"
     },
     {
+      "lang": "pt_br",
+      "text": "Grafite",
+      "info": "$(thing)Usado para$(): $(l:mechanics/fire_clay)Argila Refratária$(), Grafeno"
+    },
+    {
       "lang": "ru_ru",
       "text": "Графит",
       "info": "$(thing)Используется для$(): $(l:mechanics/fire_clay)Огнеупорная глина$(), Графен"

--- a/OresToFieldGuide/data/ores/green_sapphire.json
+++ b/OresToFieldGuide/data/ores/green_sapphire.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Safira Verde",
+      "info": "$(thing)Fonte de$(): Aluminium"
+    },
+    {
       "lang": "ru_ru",
       "text": "Зелёный сапфир",
       "info": "$(thing)Хромит$(): Алюминий"

--- a/OresToFieldGuide/data/ores/grossular.json
+++ b/OresToFieldGuide/data/ores/grossular.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Calcium, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Glossulária",
+      "info": "$(thing)Fonte de$(): Cálcio, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Гроссуляр",
       "info": "$(thing)Хромит$(): Кальций, Алюминий"

--- a/OresToFieldGuide/data/ores/gypsum.json
+++ b/OresToFieldGuide/data/ores/gypsum.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): Alabaster (dyeable) bricks"
     },
     {
+      "lang": "pt_br",
+      "text": "Gipsita",
+      "info": "$(thing)Usado para$(): Tijolos de Alabastro (tingíveis)"
+    },
+    {
       "lang": "ru_ru",
       "text": "Гипс",
       "info": "$(thing)Используется для$(): Алебастр (можно покрасить) и его кирпичи"

--- a/OresToFieldGuide/data/ores/hematite.json
+++ b/OresToFieldGuide/data/ores/hematite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Cast Iron"
         },
         {
+            "lang": "pt_br",
+            "text": "Hematita",
+            "info": "$(thing)Derrete em$(): Ferro Fundido"
+        },
+        {
             "lang": "ru_ru",
             "text": "Гематит",
             "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/ilmenite.json
+++ b/OresToFieldGuide/data/ores/ilmenite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Iron, Titanium"
     },
     {
+      "lang": "pt_br",
+      "text": "Ilmenita",
+      "info": "$(thing)Fonte de$(): Ferro, Titânio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Ильменит",
       "info": "$(thing)Хромит$(): Железо, Титан"

--- a/OresToFieldGuide/data/ores/iron.json
+++ b/OresToFieldGuide/data/ores/iron.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Cast Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Ferro",
+      "info": "$(thing)Derrete em$(): Ferro Fundido"
+    },
+    {
       "lang": "ru_ru",
       "text": "Железо",
       "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/kyanite.json
+++ b/OresToFieldGuide/data/ores/kyanite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Cianita",
+      "info": "$(thing)Fonte de$(): Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Ционит",
       "info": "$(thing)Хромит$(): Алюминий"

--- a/OresToFieldGuide/data/ores/lapis.json
+++ b/OresToFieldGuide/data/ores/lapis.json
@@ -9,6 +9,11 @@
       "info": "$(thing)Source of$(): Lazurite, Sodalite, Pyrite, Calcite"
     },
     {
+      "lang": "pt_br",
+      "text": "Lápis-lazúri",
+      "info": "$(thing)Fonte de$(): Lazurita, Sodalita, Pirita, Calcita"
+    },
+    {
       "lang": "ru_ru",
       "text": "Лазурит 2",
       "info": "$(thing)Хромит$(): Лазурит, Содалит, Пирит, Кальцит"

--- a/OresToFieldGuide/data/ores/lazurite.json
+++ b/OresToFieldGuide/data/ores/lazurite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Calcium, Sodium"
     },
     {
+      "lang": "pt_br",
+      "text": "Lazurita",
+      "info": "$(thing)Fonte de$(): Alumínio, Cálcio, Sódio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Лазурит",
       "info": "$(thing)Хромит$(): Алюминий, Кальций, Натрий"

--- a/OresToFieldGuide/data/ores/lead.json
+++ b/OresToFieldGuide/data/ores/lead.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Smelts into$(): Lead"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Chumbo",
+			"info": "$(thing)Derrete em$(): Chumbo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Свинец",
 			"info": "$(thing)Плавится в$(): Свинец"

--- a/OresToFieldGuide/data/ores/lepidolite.json
+++ b/OresToFieldGuide/data/ores/lepidolite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Potassium, Lithium, Aluminium, Fluorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Lepidorita",
+      "info": "$(thing)Fonte de$(): Potássio, Lítio, Alumínio, Flúor"
+    },
+    {
       "lang": "ru_ru",
       "text": "Лепидолит",
       "info": "$(thing)Хромит$(): Калий, Литий, Алюминий, Фтор"

--- a/OresToFieldGuide/data/ores/lithium.json
+++ b/OresToFieldGuide/data/ores/lithium.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Lithium"
     },
     {
+      "lang": "pt_br",
+      "text": "Lítio",
+      "info": "$(thing)Fonte de$(): Lítio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Литий",
       "info": "$(thing)Хромит$(): Литий"

--- a/OresToFieldGuide/data/ores/magnesite.json
+++ b/OresToFieldGuide/data/ores/magnesite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Magnesium"
     },
     {
+      "lang": "pt_br",
+      "text": "Magnesita",
+      "info": "$(thing)Fonte de$(): Magnésio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Магнезит",
       "info": "$(thing)Хромит$(): Магний"

--- a/OresToFieldGuide/data/ores/magnetite.json
+++ b/OresToFieldGuide/data/ores/magnetite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Cast Iron"
         },
         {
+            "lang": "pt_br",
+            "text": "Magnetita",
+            "info": "$(thing)Derrete em$(): Ferro Fundido"
+        },
+        {
             "lang": "ru_ru",
             "text": "Магнетит",
             "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/malachite.json
+++ b/OresToFieldGuide/data/ores/malachite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Copper"
         },
         {
+            "lang": "pt_br",
+            "text": "Malaquita",
+            "info": "$(thing)Derrete em$(): Cobre"
+        },
+        {
             "lang": "ru_ru",
             "text": "Малахит",
             "info": "$(thing)Плавится в$(): Медь"

--- a/OresToFieldGuide/data/ores/mica.json
+++ b/OresToFieldGuide/data/ores/mica.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Potassium, Aluminium, Fluorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Mica",
+      "info": "$(thing)Fonte de$(): Potássio, Alumínio, Flúor"
+    },
+    {
       "lang": "ru_ru",
       "text": "Слюда",
       "info": "$(thing)Хромит$(): Калий, Алюминий, Фтор"

--- a/OresToFieldGuide/data/ores/molybdenite.json
+++ b/OresToFieldGuide/data/ores/molybdenite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Molybdenum"
     },
     {
+      "lang": "pt_br",
+      "text": "Molibdenita",
+      "info": "$(thing)Fonte de$(): Molibdênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Молибденит",
       "info": "$(thing)Хромит$(): Молибден"

--- a/OresToFieldGuide/data/ores/molybdenum.json
+++ b/OresToFieldGuide/data/ores/molybdenum.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Molybdenum"
     },
     {
+      "lang": "pt_br",
+      "text": "Molibdênio",
+      "info": "$(thing)Fonte de$(): Molibdênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Молибден",
       "info": "$(thing)Хромит$(): Молибден"

--- a/OresToFieldGuide/data/ores/monazite.json
+++ b/OresToFieldGuide/data/ores/monazite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Phosphorous, Rare Earth"
     },
     {
+      "lang": "pt_br",
+      "text": "Monazita",
+      "info": "$(thing)Fonte de$(): Fósforo, Terra Rara"
+    },
+    {
       "lang": "ru_ru",
       "text": "Монацит",
       "info": "$(thing)Хромит$(): Фосфор, Редкая земля"

--- a/OresToFieldGuide/data/ores/naquadah.json
+++ b/OresToFieldGuide/data/ores/naquadah.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Naquadah, Tritanium"
     },
     {
+      "lang": "pt_br",
+      "text": "Naquadah",
+      "info": "$(thing)Fonte de$(): Naquadah, Tritânio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Наквада",
       "info": "$(thing)Хромит$(): Наквада, Тританий"

--- a/OresToFieldGuide/data/ores/neodymium.json
+++ b/OresToFieldGuide/data/ores/neodymium.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Neodymium"
     },
     {
+      "lang": "pt_br",
+      "text": "Neodímio",
+      "info": "$(thing)Fonte de$(): Neodímio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Неодим",
       "info": "$(thing)Хромит$(): Неодим"

--- a/OresToFieldGuide/data/ores/nether_quartz.json
+++ b/OresToFieldGuide/data/ores/nether_quartz.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): Applied Energistics 2"
     },
     {
+      "lang": "pt_br",
+      "text": "Quartzo do Nether",
+      "info": "$(thing)Usado para$(): Applied Energistics 2"
+    },
+    {
       "lang": "ru_ru",
       "text": "Незер-кварц",
       "info": "$(thing)Используется для$(): рецепты Applied Energistics 2"

--- a/OresToFieldGuide/data/ores/nickel.json
+++ b/OresToFieldGuide/data/ores/nickel.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Nickel"
     },
     {
+      "lang": "pt_br",
+      "text": "Níquel",
+      "info": "$(thing)Derrete em$(): Níquel"
+    },
+    {
       "lang": "ru_ru",
       "text": "Никель",
       "info": "$(thing)Плавится в$(): Никель"

--- a/OresToFieldGuide/data/ores/oilsands.json
+++ b/OresToFieldGuide/data/ores/oilsands.json
@@ -9,6 +9,11 @@
       "info": "$(thing)Source of$(): Freedom \uD83D\uDEE2\uD83E\uDD85\uD83D\uDDFD"
     },
     {
+      "lang": "pt_br",
+      "text": "Areias Petrolíferas",
+      "info": "$(thing)Fonte de$(): Liberdade \uD83D\uDEE2\uD83E\uDD85\uD83D\uDDFD"
+    },
+    {
       "lang": "ru_ru",
       "text": "Нефтеносный песок",
       "info": "$(thing)Хромит$(): топливо"

--- a/OresToFieldGuide/data/ores/olivine.json
+++ b/OresToFieldGuide/data/ores/olivine.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Magnesium, Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Olivina",
+      "info": "$(thing)Fonte de$(): Magnésio, Ferro"
+    },
+    {
       "lang": "ru_ru",
       "text": "Оливин",
       "info": "$(thing)Хромит$(): Магний, Железо"

--- a/OresToFieldGuide/data/ores/opal.json
+++ b/OresToFieldGuide/data/ores/opal.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Silicon, Oxygen"
     },
     {
+      "lang": "pt_br",
+      "text": "Opala",
+      "info": "$(thing)Fonte de$(): Silício, Oxigênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Опал",
       "info": "$(thing)Хромит$(): Кремний, Кислород"

--- a/OresToFieldGuide/data/ores/ostrum.json
+++ b/OresToFieldGuide/data/ores/ostrum.json
@@ -8,6 +8,11 @@
 			"lang": "en_us",
 			"text": "Ostrum",
 			"info": "$(thing)Source of$(): "
+		},
+		{
+			"lang": "pt_br",
+			"text": "Ostrum",
+			"info": "$(thing)Fonte de$(): "
 		}
 	]
 }

--- a/OresToFieldGuide/data/ores/palladium.json
+++ b/OresToFieldGuide/data/ores/palladium.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Palladium"
     },
     {
+      "lang": "pt_br",
+      "text": "Paládio",
+      "info": "$(thing)Fonte de$(): Paládio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Палладий",
       "info": "$(thing)Хромит$(): Палладий"

--- a/OresToFieldGuide/data/ores/pentlandite.json
+++ b/OresToFieldGuide/data/ores/pentlandite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Nickel"
     },
     {
+      "lang": "pt_br",
+      "text": "Pentlandita",
+      "info": "$(thing)Derrete em$(): Níquel"
+    },
+    {
       "lang": "ru_ru",
       "text": "Пентландит",
       "info": "$(thing)Плавится в$(): Никель"

--- a/OresToFieldGuide/data/ores/pitchblende.json
+++ b/OresToFieldGuide/data/ores/pitchblende.json
@@ -11,6 +11,11 @@
             "info": "$(thing)Source of$(): Uranium, Thorium, Lead"
         },
         {
+            "lang": "pt_br",
+            "text": "Pechblenda",
+            "info": "$(thing)Fonte de$(): Urânio, Tório, Chumbo"
+        },
+        {
             "lang": "ru_ru",
             "text": "Уранит",
             "info": "$(thing)Хромит$(): Уран, Торий, Свинец"

--- a/OresToFieldGuide/data/ores/platinum.json
+++ b/OresToFieldGuide/data/ores/platinum.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Smelts into$(): Platinum"
     },
     {
+      "lang": "pt_br",
+      "text": "Platina",
+      "info": "$(thing)Derrete em$(): Platina"
+    },
+    {
       "lang": "ru_ru",
       "text": "Платина",
       "info": "$(thing)Плавится в$(): Платина"

--- a/OresToFieldGuide/data/ores/plutonium.json
+++ b/OresToFieldGuide/data/ores/plutonium.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Source of$(): Plutonium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Plutônio",
+			"info": "$(thing)Fonte de$(): Plutônio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Плутоний",
 			"info": "$(thing)Хромит$(): Плутоний"

--- a/OresToFieldGuide/data/ores/pollucite.json
+++ b/OresToFieldGuide/data/ores/pollucite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Caesium, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Polucita",
+      "info": "$(thing)Fonte de$(): Césio, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Поллуцит",
       "info": "$(thing)Хромит$(): Цезий, Алюминий"

--- a/OresToFieldGuide/data/ores/powellite.json
+++ b/OresToFieldGuide/data/ores/powellite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Molybdenum"
     },
     {
+      "lang": "pt_br",
+      "text": "Powellita",
+      "info": "$(thing)Fonte de$(): Molibdênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Повеллит",
       "info": "$(thing)Хромит$(): Молибден"

--- a/OresToFieldGuide/data/ores/pyrite.json
+++ b/OresToFieldGuide/data/ores/pyrite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Cast Iron"
     },
     {
+      "lang": "pt_br",
+      "text": "Pirita",
+      "info": "$(thing)Derrete em$(): Ferro Fundido"
+    },
+    {
       "lang": "ru_ru",
       "text": "Пирит",
       "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/pyrochlore.json
+++ b/OresToFieldGuide/data/ores/pyrochlore.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Niobium"
     },
     {
+      "lang": "pt_br",
+      "text": "Pirocloro",
+      "info": "$(thing)Fonte de$(): Nióbio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Пирохлор",
       "info": "$(thing)Хромит$(): Ниобий"

--- a/OresToFieldGuide/data/ores/pyrolusite.json
+++ b/OresToFieldGuide/data/ores/pyrolusite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Manganese"
     },
     {
+      "lang": "pt_br",
+      "text": "Pirolusita",
+      "info": "$(thing)Fonte de$(): Manganês"
+    },
+    {
       "lang": "ru_ru",
       "text": "Пиролюзит",
       "info": "$(thing)Хромит$(): Марганец"

--- a/OresToFieldGuide/data/ores/pyrope.json
+++ b/OresToFieldGuide/data/ores/pyrope.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Magnesium"
     },
     {
+      "lang": "pt_br",
+      "text": "Piropo",
+      "info": "$(thing)Fonte de$(): Alumínio, Magnésio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Пироп",
       "info": "$(thing)Хромит$(): Алюминий, Магний"

--- a/OresToFieldGuide/data/ores/quartzite.json
+++ b/OresToFieldGuide/data/ores/quartzite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Used for$(): LV components"
     },
     {
+      "lang": "pt_br",
+      "text": "Quartzito",
+      "info": "$(thing)Usado para$(): Componentes LV"
+    },
+    {
       "lang": "ru_ru",
       "text": "Кварцит",
       "info": "$(thing)Используется для$(): компоненты уровня LV"

--- a/OresToFieldGuide/data/ores/realgar.json
+++ b/OresToFieldGuide/data/ores/realgar.json
@@ -11,6 +11,11 @@
 			"info": "$(thing)Source of$(): Arsenic"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Realgar",
+			"info": "$(thing)Fonte de$(): Arsênico"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Реальгар",
 			"info": "$(thing)Хромит$(): Мышьяк"

--- a/OresToFieldGuide/data/ores/red_garnet.json
+++ b/OresToFieldGuide/data/ores/red_garnet.json
@@ -9,6 +9,11 @@
       "info": "$(thing)Source of$(): Pyrope, Almandine, Spessartine"
     },
     {
+      "lang": "pt_br",
+      "text": "Granada Vermelha",
+      "info": "$(thing)Fonte de$(): Piropo, Almandina, Espessartita"
+    },
+    {
       "lang": "ru_ru",
       "text": "Красный гранат",
       "info": "$(thing)Хромит$(): Пироп, Альмандин, Спасерит"

--- a/OresToFieldGuide/data/ores/redstone.json
+++ b/OresToFieldGuide/data/ores/redstone.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Melts into$(): Redstone"
     },
     {
+      "lang": "pt_br",
+      "text": "Redstone",
+      "info": "$(thing)Derrete em$(): Redstone"
+    },
+    {
       "lang": "ru_ru",
       "text": "Редстоун",
       "info": "$(thing)Плавится в$(): Редстоун"

--- a/OresToFieldGuide/data/ores/rock_salt.json
+++ b/OresToFieldGuide/data/ores/rock_salt.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Potassium, Chlorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Sal-gema",
+      "info": "$(thing)Fonte de$(): Potássio, Cloro"
+    },
+    {
       "lang": "ru_ru",
       "text": "Каменная соль",
       "info": "$(thing)Хромит$(): Калий, Хлор"

--- a/OresToFieldGuide/data/ores/ruby.json
+++ b/OresToFieldGuide/data/ores/ruby.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Chromium, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Rubi",
+      "info": "$(thing)Fonte de$(): Cromo, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Рубин",
       "info": "$(thing)Хромит$(): Хром, Алюминий"

--- a/OresToFieldGuide/data/ores/salt.json
+++ b/OresToFieldGuide/data/ores/salt.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Sodium, Chlorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Sal",
+      "info": "$(thing)Fonte de$(): Sódio, Cloro"
+    },
+    {
       "lang": "ru_ru",
       "text": "Соль",
       "info": "$(thing)Хромит$(): Натрий, Хлор"

--- a/OresToFieldGuide/data/ores/saltpeter.json
+++ b/OresToFieldGuide/data/ores/saltpeter.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Potassium, Nitrogen"
     },
     {
+      "lang": "pt_br",
+      "text": "Salitre",
+      "info": "$(thing)Fonte de$(): Potássio, Nitrogênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Селитра",
       "info": "$(thing)Хромит$(): Калий, Азот"

--- a/OresToFieldGuide/data/ores/sapphire.json
+++ b/OresToFieldGuide/data/ores/sapphire.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Safira",
+      "info": "$(thing)Fonte de$(): Alimínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Сапфир",
       "info": "$(thing)Хромит$(): Алюминий"

--- a/OresToFieldGuide/data/ores/scheelite.json
+++ b/OresToFieldGuide/data/ores/scheelite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Tungsten"
     },
     {
+      "lang": "pt_br",
+      "text": "Sheelita",
+      "info": "$(thing)Fonte de$(): Tungstênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Шеелит",
       "info": "$(thing)Хромит$(): Вольфрам"

--- a/OresToFieldGuide/data/ores/silver.json
+++ b/OresToFieldGuide/data/ores/silver.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Silver"
         },
         {
+            "lang": "pt_br",
+            "text": "Prata Nativa",
+            "info": "$(thing)Derrete em$(): Prata"
+        },
+        {
             "lang": "ru_ru",
             "text": "Самородная Серебро",
             "info": "$(thing)Плавится в$(): Серебро"

--- a/OresToFieldGuide/data/ores/soapstone.json
+++ b/OresToFieldGuide/data/ores/soapstone.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Magnesium"
     },
     {
+      "lang": "pt_br",
+      "text": "Pedra-sabão",
+      "info": "$(thing)Fonte de$(): Magnésio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Мыльный камень",
       "info": "$(thing)Хромит$(): Магний"

--- a/OresToFieldGuide/data/ores/sodalite.json
+++ b/OresToFieldGuide/data/ores/sodalite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Sodium"
     },
     {
+      "lang": "pt_br",
+      "text": "Sodalita",
+      "info": "$(thing)Fonte de$(): Alumínio, Sódio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Содалит",
       "info": "$(thing)Хромит$(): Алюминий, Натрий"

--- a/OresToFieldGuide/data/ores/spessartine.json
+++ b/OresToFieldGuide/data/ores/spessartine.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Manganese, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Espessartita",
+      "info": "$(thing)Fonte de$(): Manganês, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Спасерит",
       "info": "$(thing)Хромит$(): Марганец, Алюминий"

--- a/OresToFieldGuide/data/ores/sphalerite.json
+++ b/OresToFieldGuide/data/ores/sphalerite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Zinc"
         },
         {
+            "lang": "pt_br",
+            "text": "Esfalerita",
+            "info": "$(thing)Derrete em$(): Zinco"
+        },
+        {
             "lang": "ru_ru",
             "text": "Сфалерит",
             "info": "$(thing)Плавится в$(): Цинк"

--- a/OresToFieldGuide/data/ores/spodumene.json
+++ b/OresToFieldGuide/data/ores/spodumene.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Lithium, Aluminium"
     },
     {
+      "lang": "pt_br",
+      "text": "Espodumena",
+      "info": "$(thing)Fonte de$(): Lítio, Alumínio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Сподумен",
       "info": "$(thing)Хромит$(): Литий, Алюминий"

--- a/OresToFieldGuide/data/ores/stibnite.json
+++ b/OresToFieldGuide/data/ores/stibnite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Smelts into$(): Antimony"
     },
     {
+      "lang": "pt_br",
+      "text": "Estibnita",
+      "info": "$(thing)Derrete em$(): Antimônio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Стибнит",
       "info": "$(thing)Плавится в$(): Сурьма"

--- a/OresToFieldGuide/data/ores/sulfur.json
+++ b/OresToFieldGuide/data/ores/sulfur.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Sulfur"
     },
     {
+      "lang": "pt_br",
+      "text": "Enxofre",
+      "info": "$(thing)Fonte de$(): Enxofre"
+    },
+    {
       "lang": "ru_ru",
       "text": "Сера",
       "info": "$(thing)Хромит$(): Сера"

--- a/OresToFieldGuide/data/ores/sylvite.json
+++ b/OresToFieldGuide/data/ores/sylvite.json
@@ -9,6 +9,11 @@
             "info": "$(thing)Used for$(): Fertiliser"
         },
         {
+            "lang": "pt_br",
+            "text": "Silvita",
+            "info": "$(thing)Fonte de$(): "
+        },
+        {
             "lang": "ru_ru",
             "text": "Сильвин",
             "info": "$(thing)Используется для$(): Удобрения"

--- a/OresToFieldGuide/data/ores/sylvite.json
+++ b/OresToFieldGuide/data/ores/sylvite.json
@@ -11,7 +11,7 @@
         {
             "lang": "pt_br",
             "text": "Silvita",
-            "info": "$(thing)Fonte de$(): "
+            "info": "$(thing)Usado para$(): Fertilizante"
         },
         {
             "lang": "ru_ru",

--- a/OresToFieldGuide/data/ores/talc.json
+++ b/OresToFieldGuide/data/ores/talc.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Magnesium"
     },
     {
+      "lang": "pt_br",
+      "text": "Talco",
+      "info": "$(thing)Fonte de$(): Magnésio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Тальк",
       "info": "$(thing)Хромит$(): Магний"

--- a/OresToFieldGuide/data/ores/tantalite.json
+++ b/OresToFieldGuide/data/ores/tantalite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Manganese, Tantalum"
     },
     {
+      "lang": "pt_br",
+      "text": "Tantalita",
+      "info": "$(thing)Fonte de$(): Manganês, Tântalo"
+    },
+    {
       "lang": "ru_ru",
       "text": "Танталит",
       "info": "$(thing)Хромит$(): Марганец, Тантал"

--- a/OresToFieldGuide/data/ores/tetrahedrite.json
+++ b/OresToFieldGuide/data/ores/tetrahedrite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Copper"
         },
         {
+            "lang": "pt_br",
+            "text": "Tetraedrita",
+            "info": "$(thing)Derrete em$(): Cobre"
+        },
+        {
             "lang": "ru_ru",
             "text": "Тетраэдрит",
             "info": "$(thing)Плавится в$(): Медь"

--- a/OresToFieldGuide/data/ores/thorium.json
+++ b/OresToFieldGuide/data/ores/thorium.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Thorium"
     },
     {
+      "lang": "pt_br",
+      "text": "Tório",
+      "info": "$(thing)Fonte de$(): Tório"
+    },
+    {
       "lang": "ru_ru",
       "text": "Торий",
       "info": "$(thing)Хромит$(): Торий"

--- a/OresToFieldGuide/data/ores/tin.json
+++ b/OresToFieldGuide/data/ores/tin.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Tin"
         },
         {
+            "lang": "pt_br",
+            "text": "Estanho",
+            "info": "$(thing)Derrete em$(): Estanho"
+        },
+        {
             "lang": "ru_ru",
             "text": "Олово",
             "info": "$(thing)Плавится в$(): Олово"

--- a/OresToFieldGuide/data/ores/topaz.json
+++ b/OresToFieldGuide/data/ores/topaz.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Fluorine"
     },
     {
+      "lang": "pt_br",
+      "text": "Topázio",
+      "info": "$(thing)Fonte de$(): Alumínio, Flúor"
+    },
+    {
       "lang": "ru_ru",
       "text": "Топаз",
       "info": "$(thing)Хромит$(): Алюминий, Фтор"

--- a/OresToFieldGuide/data/ores/tricalcium_phosphate.json
+++ b/OresToFieldGuide/data/ores/tricalcium_phosphate.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Calcium, Phosphorus"
     },
     {
+      "lang": "pt_br",
+      "text": "Fosfato Tricálcico",
+      "info": "$(thing)Fonte de$(): Cálcio, Fósforo"
+    },
+    {
       "lang": "ru_ru",
       "text": "Трикальцийфосфат",
       "info": "$(thing)Хромит$(): Кальций, Фосфор"

--- a/OresToFieldGuide/data/ores/trona.json
+++ b/OresToFieldGuide/data/ores/trona.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Sodium"
     },
     {
+      "lang": "pt_br",
+      "text": "Trona",
+      "info": "$(thing)Fonte de$(): Sódio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Трона",
       "info": "$(thing)Хромит$(): Натрий"

--- a/OresToFieldGuide/data/ores/tungstate.json
+++ b/OresToFieldGuide/data/ores/tungstate.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Tungsten, Lithium"
     },
     {
+      "lang": "pt_br",
+      "text": "Tungstato",
+      "info": "$(thing)Fonte de$(): Tungstênio, Lítio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Вольфрамат",
       "info": "$(thing)Хромит$(): Вольфрам, Литий"

--- a/OresToFieldGuide/data/ores/uraninite.json
+++ b/OresToFieldGuide/data/ores/uraninite.json
@@ -11,6 +11,11 @@
             "info": "$(thing)Source of$(): Uranium"
         },
         {
+            "lang": "pt_br",
+            "text": "Uraninita",
+            "info": "$(thing)Fonte de$(): Urânio"
+        },
+        {
             "lang": "ru_ru",
             "text": "Уранинит",
             "info": "$(thing)Хромит$(): Уран"

--- a/OresToFieldGuide/data/ores/vanadium_magnetite.json
+++ b/OresToFieldGuide/data/ores/vanadium_magnetite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Iron, Vanadium"
     },
     {
+      "lang": "pt_br",
+      "text": "Magnetita de Vanádio",
+      "info": "$(thing)Fonte de$(): Ferro, Vanádio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Ванадий магнетит",
       "info": "$(thing)Хромит$(): Железо, Ванадий"

--- a/OresToFieldGuide/data/ores/wulfenite.json
+++ b/OresToFieldGuide/data/ores/wulfenite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Lead, Molybdenum"
     },
     {
+      "lang": "pt_br",
+      "text": "Wulfenita",
+      "info": "$(thing)Fonte de$(): Chumbo, Molibdênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Вульфенит",
       "info": "$(thing)Хромит$(): Свинец, Молибден"

--- a/OresToFieldGuide/data/ores/yellow_garnet.json
+++ b/OresToFieldGuide/data/ores/yellow_garnet.json
@@ -9,6 +9,11 @@
       "info": "$(thing)Source of$(): Andradite, Grossular, Uvarovite"
     },
     {
+      "lang": "pt_br",
+      "text": "Granada Amarela",
+      "info": "$(thing)Fonte de$(): Andradita, Glossulária, Uvarovita"
+    },
+    {
       "lang": "ru_ru",
       "text": "Жёлтый гранат",
       "info": "$(thing)Хромит$(): Андрадит, Гроссуляр, Уваровит"

--- a/OresToFieldGuide/data/ores/yellow_limonite.json
+++ b/OresToFieldGuide/data/ores/yellow_limonite.json
@@ -10,6 +10,11 @@
             "info": "$(thing)Melts into$(): Cast Iron"
         },
         {
+            "lang": "pt_br",
+            "text": "Limonita Amarela",
+            "info": "$(thing)Derrete em$(): Ferro Fundido"
+        },
+        {
             "lang": "ru_ru",
             "text": "Жёлтый лимонит",
             "info": "$(thing)Плавится в$(): Железо"

--- a/OresToFieldGuide/data/ores/zeolite.json
+++ b/OresToFieldGuide/data/ores/zeolite.json
@@ -10,6 +10,11 @@
       "info": "$(thing)Source of$(): Aluminium, Oxygen"
     },
     {
+      "lang": "pt_br",
+      "text": "Zeólita",
+      "info": "$(thing)Fonte de$(): Alumínio, Oxigênio"
+    },
+    {
       "lang": "ru_ru",
       "text": "Цеолит",
       "info": "$(thing)Хромит$(): Алюминий, Кислород"


### PR DESCRIPTION
- Added translations for Ostrum, Palladium, Pentlandite, Pitchblende, Platinum, Plutonium, Pollucite, Powellite, Pyrite, Pyrochlore, Pyrolusite, Pyrope, Quartzite, Realgar, Red Garnet, Redstone, Rock Salt, Ruby, Salt, Saltpeter, Sapphire, Scheelite, Silver, Soapstone, Sodalite, Spessartine, Sphalerite, Spodumene, Stibnite, Sulfur, Sylvite, Talc, Tantalite, Tetrahedrite, Thorium, Tin, Topaz, Tricalcium Phosphate, Trona, Tungstate, Uraninite, Vanadium Magnetite, Wulfenite, Yellow Garnet, Yellow Limonite, and Zeolite.