### PR TITLE
Add Portuguese translations for various ores in moon and nether veins

### DIFF
--- a/OresToFieldGuide/data/veins/earth/deep_garnet_amethyst.json
+++ b/OresToFieldGuide/data/veins/earth/deep_garnet_amethyst.json
@@ -52,6 +52,10 @@
 			"text": "Amethyst & Garnet"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Ametista e Granada"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Аметист и гранат"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_garnet_opal.json
+++ b/OresToFieldGuide/data/veins/earth/deep_garnet_opal.json
@@ -46,6 +46,10 @@
 			"text": "Opal & Garnet"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Opala e Granada"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Опал и гранат"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_gold.json
+++ b/OresToFieldGuide/data/veins/earth/deep_gold.json
@@ -44,6 +44,10 @@
 			"text": "Gold (Deep)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Ouro (Profundo)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Золото (Глубокое)"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_hematite.json
+++ b/OresToFieldGuide/data/veins/earth/deep_hematite.json
@@ -46,6 +46,10 @@
 			"text": "Hematite, Goethite, & Ruby"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Hematita, Goethita e Rubi"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гематит, Гётит, Рубин"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_limonite.json
+++ b/OresToFieldGuide/data/veins/earth/deep_limonite.json
@@ -39,6 +39,10 @@
 			"text": "Goethite & Malachite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Goethita e Malaquita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гётит и Малахит"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_magnetite.json
+++ b/OresToFieldGuide/data/veins/earth/deep_magnetite.json
@@ -47,6 +47,10 @@
 			"text": "Chromite & Magnetite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cromita e Magnetita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Хромит и Магнетит"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_molybdenum.json
+++ b/OresToFieldGuide/data/veins/earth/deep_molybdenum.json
@@ -40,6 +40,10 @@
 			"text": "Wulfenite & Molybdenite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Wulfenita e Molibdenita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Вульфенит & Молибденит"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_pitchblende.json
+++ b/OresToFieldGuide/data/veins/earth/deep_pitchblende.json
@@ -38,6 +38,10 @@
 			"text": "Uraninite & Pitchblende"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Uraninita e Pechblenda"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Уранинит и Уранит"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_sapphire.json
+++ b/OresToFieldGuide/data/veins/earth/deep_sapphire.json
@@ -42,6 +42,10 @@
 			"text": "Sapphire & Almandine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Safira e Almandina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сапфир и Альмандин"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_scheelite.json
+++ b/OresToFieldGuide/data/veins/earth/deep_scheelite.json
@@ -35,6 +35,10 @@
 			"text": "Scheelite & Tungstate"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Sheelita e Tungstato"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Шеелит и Вольфрамат"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_sheldonite.json
+++ b/OresToFieldGuide/data/veins/earth/deep_sheldonite.json
@@ -39,6 +39,10 @@
 			"text": "Cooperite & Bornite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cooperita e Bornita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Шелдонит и Борнит"
 		},

--- a/OresToFieldGuide/data/veins/earth/deep_topaz.json
+++ b/OresToFieldGuide/data/veins/earth/deep_topaz.json
@@ -45,6 +45,10 @@
 			"text": "Topaz & Chalcocite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Topázio e Calcocita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Топаз и Халькозин"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_apatite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_apatite.json
@@ -41,6 +41,10 @@
 			"text": "Apatite & Pyrochlore"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Apatita e Pirocloro"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Апатит и Пирохлор"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_basaltic_sands.json
+++ b/OresToFieldGuide/data/veins/earth/normal_basaltic_sands.json
@@ -38,6 +38,10 @@
 			"text": "Mineral Sands"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Areias Minerais"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Минеральные пески"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_beryllium.json
+++ b/OresToFieldGuide/data/veins/earth/normal_beryllium.json
@@ -39,6 +39,10 @@
 			"text": "Emerald & Beryllium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esmeralda e Berílio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Изумруд и Бериллий"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_bismuthinite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_bismuthinite.json
@@ -45,6 +45,10 @@
 			"text": "Bismuth (Normal)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bismuto (Normal)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Висмут (Обычный)"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_cassiterite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_cassiterite.json
@@ -42,6 +42,10 @@
 			"text": "Cassiterite (Normal)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cassiterita (Normal)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Касситерит (Обычный)"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_coal.json
+++ b/OresToFieldGuide/data/veins/earth/normal_coal.json
@@ -43,6 +43,10 @@
 			"text": "Coal"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Carvão"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Уголь"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_copper.json
+++ b/OresToFieldGuide/data/veins/earth/normal_copper.json
@@ -44,6 +44,10 @@
 			"text": "Copper & Chalcopyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cobre e Calcopirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Медь и Халькопирит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_garnet_tin.json
+++ b/OresToFieldGuide/data/veins/earth/normal_garnet_tin.json
@@ -59,6 +59,10 @@
 			"text": "Garnet & Cassiterite Sands"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Granada e Areia Cassiterita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гранатовый и Касситеритовый песок"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_garnierite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_garnierite.json
@@ -65,6 +65,11 @@
 			"info": "Can't find it? Gabbro always spawns below $(thing)Basalt$(), and Gabbro dikes in oceans can be useful too!"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Garnierita e Cobaltita",
+			"info": "Não consegue encontrar? O Gabro sempre gera abaixo do $(thing)Basalto$(), e diques de Gabro nos oceanos também podem ser úteis!"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гарниерит и Кобальтит",
 			"info": "Не получается найти это? Габбро всегда генерируется под $(thing)Базальтом$(), а на дне океана легко обнаружить столбы, ведущие к нижнему слою!"

--- a/OresToFieldGuide/data/veins/earth/normal_gold.json
+++ b/OresToFieldGuide/data/veins/earth/normal_gold.json
@@ -48,6 +48,10 @@
 			"text": "Gold, Limonite, & Hematite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Ouro, Limonita e Hematita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Золото, Лимонит и Гематит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_graphite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_graphite.json
@@ -71,6 +71,10 @@
 			"text": "Graphite & Diamond"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Grafite e Diamante"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Графит и Алмаз"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_hematite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_hematite.json
@@ -44,6 +44,10 @@
 			"text": "Hematite & Limonite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Hematita e Limonita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гематит и Лимонит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_lapis.json
+++ b/OresToFieldGuide/data/veins/earth/normal_lapis.json
@@ -41,6 +41,10 @@
 			"text": "Lapis, Lazurite, & Sodalite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Lápis-lazúri, Lazurita e Sodalita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Лазурит, Лазурит 2 и Содалит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_limonite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_limonite.json
@@ -42,6 +42,10 @@
 			"text": "Limonite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Limonita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Лимонит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_lubricant.json
+++ b/OresToFieldGuide/data/veins/earth/normal_lubricant.json
@@ -42,6 +42,10 @@
 			"text": "Soapstone, Talc, & Trona"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Pedra-sabão, Talco e Trona"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Мыльный камень, Тальк и Трона"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_magnetite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_magnetite.json
@@ -47,6 +47,10 @@
 			"text": "Magnetite & Vanadium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Magnetita e Vanádio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Магнетит и Ванадий"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_manganese.json
+++ b/OresToFieldGuide/data/veins/earth/normal_manganese.json
@@ -46,6 +46,10 @@
 			"text": "Manganese & Tantalum"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Manganês e Tântalo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Марганец и Тантал"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_mica.json
+++ b/OresToFieldGuide/data/veins/earth/normal_mica.json
@@ -43,6 +43,10 @@
 			"text": "Kyanite, Mica, & Bauxite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cianita, Mica e Bauxita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Ционит, Слюда и Боксит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_monazite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_monazite.json
@@ -34,6 +34,10 @@
 			"text": "Bastnasite & Monazite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bastnasita e Monazita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Бастнезит и Монацит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_oilsands.json
+++ b/OresToFieldGuide/data/veins/earth/normal_oilsands.json
@@ -30,6 +30,10 @@
 			"text": "Oilsands"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Areias Petrolíferas"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Нефтеносный песок"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_olivine.json
+++ b/OresToFieldGuide/data/veins/earth/normal_olivine.json
@@ -42,6 +42,10 @@
 			"text": "Bentonite & Olivine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bentonita e Olivina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Бентонит и Оливин"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_quartz.json
+++ b/OresToFieldGuide/data/veins/earth/normal_quartz.json
@@ -39,6 +39,10 @@
 			"text": "Quartzes"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Quartzos"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Кварцы"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_redstone.json
+++ b/OresToFieldGuide/data/veins/earth/normal_redstone.json
@@ -38,6 +38,11 @@
 			"info": "Can't find it? Granite always spawns below $(thing)Rhyolite$(), and looking in oceans can be useful too!"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Redstone, Cinábrio e Rubi",
+			"info": "Não consegue encontrar? O Granito sempre aparece abaixo de $(thing)Riolito$(), e procurar nos oceanos também pode ser útil!"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Редстоун, Киноварь и Рубин",
 			"info": "Не получается найти это? На дне океана легко увидеть красное свечение!"

--- a/OresToFieldGuide/data/veins/earth/normal_salt.json
+++ b/OresToFieldGuide/data/veins/earth/normal_salt.json
@@ -41,6 +41,10 @@
 			"text": "Salts & Borax"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Sais e Bórax"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Соли и Бура"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_saltpeter.json
+++ b/OresToFieldGuide/data/veins/earth/normal_saltpeter.json
@@ -47,6 +47,10 @@
 			"text": "Saltpeter & Electrotine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Salitre e Eletrotina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Селитра и Электротин"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_silver.json
+++ b/OresToFieldGuide/data/veins/earth/normal_silver.json
@@ -38,6 +38,10 @@
 			"text": "Silver, Galena, & Lead"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Prata, Galena e Chumbo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Серебро, Галена и Свинец"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_sphalerite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_sphalerite.json
@@ -46,6 +46,10 @@
 			"text": "Sphalerite & Pyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esfalerita e Pirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сфалерит & Пирит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_spodumene.json
+++ b/OresToFieldGuide/data/veins/earth/normal_spodumene.json
@@ -45,6 +45,10 @@
 			"text": "Spodumene & Lepidolite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Espodumena e Lepidolita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сподумен и Лепидолит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_sulfur.json
+++ b/OresToFieldGuide/data/veins/earth/normal_sulfur.json
@@ -38,6 +38,10 @@
 			"text": "Sulfur & Pyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Enxofre e Pirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сера и Пирит"
 		},

--- a/OresToFieldGuide/data/veins/earth/normal_tetrahedrite.json
+++ b/OresToFieldGuide/data/veins/earth/normal_tetrahedrite.json
@@ -42,6 +42,10 @@
 			"text": "Tetrahedrite (Normal)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Tetraedrita (Normal)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Тетраэдрит (обычный)"
 		},

--- a/OresToFieldGuide/data/veins/earth/surface_bismuthinite.json
+++ b/OresToFieldGuide/data/veins/earth/surface_bismuthinite.json
@@ -47,6 +47,10 @@
 			"text": "Bismuth (Surface)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bismuto (Superfície)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Висмут (Поверхностный)"
 		},

--- a/OresToFieldGuide/data/veins/earth/surface_cassiterite.json
+++ b/OresToFieldGuide/data/veins/earth/surface_cassiterite.json
@@ -42,6 +42,10 @@
 			"text": "Cassiterite (Surface)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cassiterita (Superfície)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Касситерит (Поверхностный)"
 		},

--- a/OresToFieldGuide/data/veins/earth/surface_copper.json
+++ b/OresToFieldGuide/data/veins/earth/surface_copper.json
@@ -45,6 +45,10 @@
 			"text": "Chalcopyrite & Realgar"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Calcopirita e Realgar"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Халькопирит и Реальгар"
 		},

--- a/OresToFieldGuide/data/veins/earth/surface_sphalerite.json
+++ b/OresToFieldGuide/data/veins/earth/surface_sphalerite.json
@@ -47,6 +47,10 @@
 			"text": "Sphalerite & Sulfur"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esfalerita e Enxofre"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сфалерит и Сера"
 		},

--- a/OresToFieldGuide/data/veins/earth/surface_tetrahedrite.json
+++ b/OresToFieldGuide/data/veins/earth/surface_tetrahedrite.json
@@ -43,6 +43,10 @@
 			"text": "Tetrahedrite (Surface)"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Tetraedrita (Superfície)"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Тетраэдрит (Поверхностный)"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_apatite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_apatite.json
@@ -42,6 +42,10 @@
 			"text": "Apatite & Pyrochlore"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Apatita e Pirocloro"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Апатит и Пирохлор"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_bauxite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_bauxite.json
@@ -40,6 +40,10 @@
 			"text": "Bauxite & Ilmenite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bauxita e Ilmenita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Боксит и Ильменит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_beryllium.json
+++ b/OresToFieldGuide/data/veins/moon/moon_beryllium.json
@@ -53,6 +53,10 @@
 			"text": "Emerald & Beryllium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esmeralda e Berílio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Изумруд и Бериллий"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_desh.json
+++ b/OresToFieldGuide/data/veins/moon/moon_desh.json
@@ -45,6 +45,10 @@
 			"text": "Desh & Ilmenite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Desh e Ilmenita"
+		},
+		{
 			"lang": "uk_ua",
 			"text": "Деш і Ільменіт"
 		}

--- a/OresToFieldGuide/data/veins/moon/moon_garnierite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_garnierite.json
@@ -47,6 +47,10 @@
 			"text": "Garnierite & Cobaltite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Garnierita e Cobaltita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гарниерит и Кобальтит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_graphite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_graphite.json
@@ -46,6 +46,10 @@
 			"text": "Graphite & Diamond"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Grafite e Diamante"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Графит и Алмаз"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_lubricant.json
+++ b/OresToFieldGuide/data/veins/moon/moon_lubricant.json
@@ -44,6 +44,10 @@
 			"text": "Soapstone, Talc, & Trona"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Pedra-sabão, Talco e Trona"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Мыльный камень, Тальк и Трона"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_magnetite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_magnetite.json
@@ -47,6 +47,10 @@
 			"text": "Chromite & Magnetite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cromita e Magnetita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Хромит и Магнетит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_manganese.json
+++ b/OresToFieldGuide/data/veins/moon/moon_manganese.json
@@ -41,6 +41,10 @@
 			"text": "Manganese & Tantalum"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Manganês e Tântalo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Марганец и Тантал"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_mica.json
+++ b/OresToFieldGuide/data/veins/moon/moon_mica.json
@@ -47,6 +47,10 @@
 			"text": "Kyanite, Mica, & Bauxite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cianita, Mica e Bauxita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Ционит, Слюда и Боксит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_molybdenum.json
+++ b/OresToFieldGuide/data/veins/moon/moon_molybdenum.json
@@ -44,6 +44,10 @@
 			"text": "Wulfenite & Molybdenite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Wulfenita e Molibdenita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Вульфенит & Молибденит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_monazite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_monazite.json
@@ -43,6 +43,10 @@
 			"text": "Bastnasite & Monazite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bastnasita e Monazita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Бастнезит и Монацит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_pyrolusite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_pyrolusite.json
@@ -44,6 +44,10 @@
 			"text": "Pyrolusite and Cobalt"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Pirolusita e Cobalto"
+		},
+		{
 			"lang": "uk_ua",
 			"text": "Піролюзит і Кобальт"
 		}

--- a/OresToFieldGuide/data/veins/moon/moon_quartz.json
+++ b/OresToFieldGuide/data/veins/moon/moon_quartz.json
@@ -49,6 +49,10 @@
 			"text": "Certus Quartz"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Quartzo Certus"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Истинный кварц"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_redstone.json
+++ b/OresToFieldGuide/data/veins/moon/moon_redstone.json
@@ -42,6 +42,10 @@
 			"text": "Redstone, Cinnabar, & Ruby"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Redstone, Cinábrio e Rubi"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Редстоун, Киноварь и Рубин"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_saltpeter.json
+++ b/OresToFieldGuide/data/veins/moon/moon_saltpeter.json
@@ -43,6 +43,10 @@
 			"text": "Saltpeter & Electrotine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Salitre e Eletrotina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Селитра и Электротин"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_sapphire.json
+++ b/OresToFieldGuide/data/veins/moon/moon_sapphire.json
@@ -46,6 +46,10 @@
 			"text": "Sapphire & Almandine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Safira e Almandina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сапфир и Альмандин"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_scheelite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_scheelite.json
@@ -39,6 +39,10 @@
 			"text": "Scheelite & Tungstate"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Sheelita e Tungstato"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Шеелит и Вольфрамат"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_sheldonite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_sheldonite.json
@@ -42,6 +42,10 @@
 			"text": "Cooperite & Bornite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cooperita e Bornita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Шелдонит и Борнит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_silver.json
+++ b/OresToFieldGuide/data/veins/moon/moon_silver.json
@@ -44,6 +44,10 @@
 			"text": "Silver, Galena, & Lead"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Prata, Galena e Chumbo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Серебро, Галена и Свинец"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_sphalerite.json
+++ b/OresToFieldGuide/data/veins/moon/moon_sphalerite.json
@@ -41,6 +41,10 @@
 			"text": "Sphalerite & Pyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esfalerita e Pirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сфалерит & Пирит"
 		},

--- a/OresToFieldGuide/data/veins/moon/moon_topaz.json
+++ b/OresToFieldGuide/data/veins/moon/moon_topaz.json
@@ -48,6 +48,10 @@
 			"text": "Topaz & Chalcocite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Topázio e Calcosita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Топаз и Халькозин"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_anthracite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_anthracite.json
@@ -29,6 +29,10 @@
 			"text": "Anthracite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Antracito"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Антрацит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_apatite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_apatite.json
@@ -39,6 +39,10 @@
 			"text": "Apatite & Pyrochlore"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Apatita e Pirocloro"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Апатит и Пирохлор"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_basaltic_sands.json
+++ b/OresToFieldGuide/data/veins/nether/nether_basaltic_sands.json
@@ -45,6 +45,10 @@
 			"text": "Mineral Sands"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Areias Minerais"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Минеральные пески"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_beryllium.json
+++ b/OresToFieldGuide/data/veins/nether/nether_beryllium.json
@@ -49,6 +49,10 @@
 			"text": "Emerald & Beryllium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esmeralda e Berílio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Изумруд и Бериллий"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_cassiterite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_cassiterite.json
@@ -45,6 +45,10 @@
 			"text": "Cassiterite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cassiterita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Касситерит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_copper.json
+++ b/OresToFieldGuide/data/veins/nether/nether_copper.json
@@ -46,6 +46,10 @@
 			"text": "Copper & Chalcopyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cobre e Calcopirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Медь и Халькопирит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_garnet.json
+++ b/OresToFieldGuide/data/veins/nether/nether_garnet.json
@@ -47,6 +47,10 @@
 			"text": "Amethyst, Opal, & Garnet"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Ametista, Opala e Granada"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Аметист, Опал и гранат"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_garnet_tin.json
+++ b/OresToFieldGuide/data/veins/nether/nether_garnet_tin.json
@@ -50,6 +50,10 @@
 			"text": "Garnet & Cassiterite Sands"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Granada e Areia Cassiterita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гранатовый и Касситеритовый песок"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_garnierite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_garnierite.json
@@ -49,6 +49,10 @@
 			"text": "Garnierite & Cobaltite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Garnierita e Cobaltita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гарниерит и Кобальтит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_goethite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_goethite.json
@@ -46,6 +46,10 @@
 			"text": "Goethite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Goethita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гётит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_gold.json
+++ b/OresToFieldGuide/data/veins/nether/nether_gold.json
@@ -46,6 +46,10 @@
 			"text": "Gold & Hematite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Ouro e Hematita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Золото и Гематит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_graphite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_graphite.json
@@ -60,6 +60,10 @@
 			"text": "Graphite & Diamond"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Grafite e Diamante"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Графит и Алмаз"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_hematite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_hematite.json
@@ -49,6 +49,10 @@
 			"text": "Hematite & Limonite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Hematita e Limonita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Гематит и Лимонит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_lapis.json
+++ b/OresToFieldGuide/data/veins/nether/nether_lapis.json
@@ -45,6 +45,10 @@
 			"text": "Lapis, Lazurite, & Sodalite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Lápis-lazúri, Lazurita e Sodalita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Лазурит, Лазурит 2 и Содалит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_lubricant.json
+++ b/OresToFieldGuide/data/veins/nether/nether_lubricant.json
@@ -53,6 +53,10 @@
 			"text": "Soapstone, Talc, & Trona"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Pedra-sabão, Talco e Trona"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Мыльный камень, Тальк и Трона"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_magnetite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_magnetite.json
@@ -48,6 +48,10 @@
 			"text": "Chromite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cromita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Хромит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_manganese.json
+++ b/OresToFieldGuide/data/veins/nether/nether_manganese.json
@@ -46,6 +46,10 @@
 			"text": "Manganese & Tantalum"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Manganês e Tântalo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Марганец и Тантал"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_mica.json
+++ b/OresToFieldGuide/data/veins/nether/nether_mica.json
@@ -44,6 +44,10 @@
 			"text": "Kyanite, Mica, & Bauxite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cianita, Mica e Bauxita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Ционит, Слюда и Боксит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_molybdenum.json
+++ b/OresToFieldGuide/data/veins/nether/nether_molybdenum.json
@@ -46,6 +46,10 @@
 			"text": "Wulfenite & Molybdenite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Wulfenita e Molibdenita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Вульфенит & Молибденит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_monazite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_monazite.json
@@ -44,6 +44,10 @@
 			"text": "Bastnasite & Monazite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bastnasita e Monazita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Бастнезит и Монацит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_naquadah.json
+++ b/OresToFieldGuide/data/veins/nether/nether_naquadah.json
@@ -34,6 +34,10 @@
 			"text": "Naquadah & Plutonium"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Naquadah e Plutônio"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Наквада и Плутоний"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_olivine.json
+++ b/OresToFieldGuide/data/veins/nether/nether_olivine.json
@@ -46,6 +46,10 @@
 			"text": "Bentonite & Olivine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Bentonita e Olivina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Бентонит и Оливин"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_pitchblende.json
+++ b/OresToFieldGuide/data/veins/nether/nether_pitchblende.json
@@ -38,6 +38,10 @@
 			"text": "Uraninite & Pitchblende"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Uraninita e Pechblenda"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Уранинит и Уранит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_quartz.json
+++ b/OresToFieldGuide/data/veins/nether/nether_quartz.json
@@ -43,6 +43,10 @@
 			"text": "Nether Quartz"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Nether Quartzo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Незер-кварц"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_redstone.json
+++ b/OresToFieldGuide/data/veins/nether/nether_redstone.json
@@ -39,6 +39,10 @@
 			"text": "Redstone, Cinnabar, & Ruby"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Redstone, Cinábrio e Rubi"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Редстоун, Киноварь и Рубин"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_saltpeter.json
+++ b/OresToFieldGuide/data/veins/nether/nether_saltpeter.json
@@ -48,6 +48,10 @@
 			"text": "Saltpeter & Electrotine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Salitre e Eletrotina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Селитра и Электротин"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_sapphire.json
+++ b/OresToFieldGuide/data/veins/nether/nether_sapphire.json
@@ -49,6 +49,10 @@
 			"text": "Sapphire & Almandine"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Safira e Almandina"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сапфир и Альмандин"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_scheelite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_scheelite.json
@@ -43,6 +43,10 @@
 			"text": "Scheelite & Tungstate"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Sheelita e Tungstato"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Шеелит и Вольфрамат"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_sheldonite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_sheldonite.json
@@ -45,6 +45,10 @@
 			"text": "Cooperite & Bornite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Cooperita e Bornita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Шелдонит и Борнит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_silver.json
+++ b/OresToFieldGuide/data/veins/nether/nether_silver.json
@@ -41,6 +41,10 @@
 			"text": "Silver, Galena, & Lead"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Prata, Galena e Chumbo"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Серебро, Галена и Свинец"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_sphalerite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_sphalerite.json
@@ -42,6 +42,10 @@
 			"text": "Sphalerite & Pyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Esfalerita e Pirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сфалерит & Пирит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_sulfur.json
+++ b/OresToFieldGuide/data/veins/nether/nether_sulfur.json
@@ -41,6 +41,10 @@
 			"text": "Sulfur & Pyrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Enxofre e Pirita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сера и Пирит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_sylvite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_sylvite.json
@@ -24,6 +24,10 @@
 			"text": "Sylvite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Silvita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Сильвин"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_tetrahedrite.json
+++ b/OresToFieldGuide/data/veins/nether/nether_tetrahedrite.json
@@ -42,6 +42,10 @@
 			"text": "Tetrahedrite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Tetraedrita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Тетраэдрит"
 		},

--- a/OresToFieldGuide/data/veins/nether/nether_topaz.json
+++ b/OresToFieldGuide/data/veins/nether/nether_topaz.json
@@ -46,6 +46,10 @@
 			"text": "Topaz & Chalcocite"
 		},
 		{
+			"lang": "pt_br",
+			"text": "Topázio e Calcosita"
+		},
+		{
 			"lang": "ru_ru",
 			"text": "Топаз и Халькозин"
 		},


### PR DESCRIPTION
- Added translations for bauxite, beryllium, desh, garnierite, graphite, lubricant, magnetite, manganese, mica, molybdenum, monazite, pyrolusite, quartz, redstone, saltpeter, sapphire, scheelite, sheldonite, silver, sphalerite, topaz, and others in both moon and nether vein JSON files.