### PR TITLE
Adding Trona for Soda Ash

### DIFF
--- a/OresToFieldGuide/data/veins/mars/mars_lubricant.json
+++ b/OresToFieldGuide/data/veins/mars/mars_lubricant.json
@@ -7,7 +7,7 @@
 		"density": 0.25,
 		"min_y": 0,
 		"max_y": 70,
-		"size": 50
+		"size": 40
 	},
 	"ores": [
 		{

--- a/OresToFieldGuide/data/veins/mars/mars_lubricant.json
+++ b/OresToFieldGuide/data/veins/mars/mars_lubricant.json
@@ -7,25 +7,29 @@
 		"density": 0.25,
 		"min_y": 0,
 		"max_y": 70,
-		"size": 30
+		"size": 50
 	},
 	"ores": [
 		{
 			"ore": "soapstone",
-			"weight": 30,
-			"block_weight": 1
+			"weight": 10
 		},
 		{
 			"ore": "talc",
-			"weight": 20
+			"weight": 20,
+			"block_weight": 1
 		},
 		{
 			"ore": "glauconite_sand",
-			"weight": 25
+			"weight": 15
+		},
+		{
+			"ore": "trona",
+			"weight": 15
 		},
 		{
 			"ore": "pentlandite",
-			"weight": 15
+			"weight": 5
 		},
 		{
 			"ore": "hematite",
@@ -51,11 +55,11 @@
 	"translations": [
 		{
 			"lang": "en_us",
-			"text": "Soapstone, Talc, & Glauconite"
+			"text": "Trona, Talc, & Glauconite"
 		},
 		{
 			"lang": "zh_cn",
-			"text": "皂石, 滑石, 海绿石矿砂"
+			"text": "皂石, 滑石, 海绿石矿砂 CHANGE HERE"
 		}
 	]
 }


### PR DESCRIPTION
Soda Ash will be required for Tungsten so I added Trona to this vein and rebalance a bit the ratio so it's not the same as other planets. Also increase the size so you can get quite a chunk of Soda Ash.