### PR TITLE
Differentiate between salts

### DIFF
--- a/LanguageMerger/LanguageFiles/gtceu/en_us/items.json
+++ b/LanguageMerger/LanguageFiles/gtceu/en_us/items.json
@@ -59,5 +59,16 @@
 	"item.gtceu.naquadah_credit": "§7262,144 Credits",
 	"item.gtceu.neutronium_credit": "§72,097,152 Credits",
 
-	"item.gtceu.wood_plate": "Medium Density Fiberboard"
+	"item.gtceu.wood_plate": "Medium Density Fiberboard",
+
+	"item.gtceu.chipped_salt_gem": "Chipped Salt Crystal",
+	"item.gtceu.chipped_rock_salt_gem": "Chipped Rock Salt Crystal",
+	"item.gtceu.flawed_salt_gem": "Flawed Salt Crystal",
+	"item.gtceu.flawed_rock_salt_gem": "Flawed Rock Salt Crystal",
+	"item.gtceu.salt_gem": "Salt Crystal",
+	"item.gtceu.rock_salt_gem": "Rock Salt Crystal",
+	"item.gtceu.exquisite_salt_gem": "Exquisite Salt Crystal",
+	"item.gtceu.exquisite_rock_salt_gem": "Exquisite Rock Salt Crystal",
+	"item.gtceu.flawless_salt_gem": "Flawless Salt Crystal",
+	"item.gtceu.flawless_rock_salt_gem": "Flawless Rock Salt Crystal"
 }

--- a/LanguageMerger/LanguageFiles/tfc/en_us/items.json
+++ b/LanguageMerger/LanguageFiles/tfc/en_us/items.json
@@ -3,5 +3,6 @@
     "item.tfc.powder.saltpeter": "Saltpeter Powder",
 	"item.tfc.powder.sulfur": "Sulfur Powder",
     "item.tfc.jute_net": "Burlap Net",
-    "item.tfc.dirty_jute_net": "Dirty Burlap Net"
+    "item.tfc.dirty_jute_net": "Dirty Burlap Net",
+	"item.tfc.powder.salt": "Table Salt"
 }


### PR DESCRIPTION
## What is the new behavior?
Reduce confusion between salt (TFC), salt (gem), and salt (dust).

## Implementation Details
Salt and rock salt gems are now "Salt Crystals"
TFC salt is "Table Salt"
Salt and rock salt dust remain "Salt"

## Alternatives Considered

TFC salt remains "Salt" and and TFG dusts renamed to "Salt Dusts"