### PR TITLE
Fix typos in Create: Armorer and Applied Armorer and standardise language used

### DIFF
--- a/LanguageMerger/LanguageFiles/tacz/en_us/applied_armorer.json
+++ b/LanguageMerger/LanguageFiles/tacz/en_us/applied_armorer.json
@@ -6,10 +6,21 @@
   "applied_armorer.attachment.extended_mid_mag_aa_1.name": "Fluix Grooved Magazine",
   "applied_armorer.attachment.extended_mid_mag_aa_2.name": "§9Fluix Grooved Magazine",
   "applied_armorer.attachment.extended_mid_mag_aa_3.name": "§dFluix Grooved Magazine",
-  
+
+  "applied_armorer.attachment.si_pricision.name": "§aPrecision Scope",
+  "applied_armorer.attachment.si_double_sided_mirror.name": "\"Double Sided Mirror\" Scope",
+  "applied_armorer.attachment.si_ms_12.name": "§aMS-12 Scope",
+  "applied_armorer.attachment.scope_ms_14.name": "§eMS-14 Scope",
+  "applied_armorer.attachment.scope_xgs_905.name": "§eXGS-905 Scope",
+  "applied_armorer.attachment.muzzle_classic.name": "Classic Suppressor",
+  "applied_armorer.attachment.muzzle_ns_1.name": "NS-1 Suppressor",
+  "applied_armorer.attachment.muzzle_commander.name": "Commander Muzzle Brake",
+  "applied_armorer.attachment.muzzle_bs_mod4.name": "BS-Mod.4 Compensator",
   "applied_armorer.attachment.grip_lf11.name": "LF-11 Laser-Grip",
   "applied_armorer.attachment.grip_sl_2.name": "SL-2 Laser-Grip",
   "applied_armorer.attachment.grip_stable.name": "ST-61 Grip",
   "applied_armorer.attachment.grip_light.name": "LI-13 Grip",
-  "applied_armorer.attachment.grip_hf_17.name": "HF-17 Grip"
+  "applied_armorer.attachment.grip_hf_17.name": "HF-17 Grip",
+
+  "tooltip.niklas_pistol_semi_pride": "§7Guns are faster than knives at any distance... right?"
 }

--- a/LanguageMerger/LanguageFiles/tacz/en_us/create_armorer.json
+++ b/LanguageMerger/LanguageFiles/tacz/en_us/create_armorer.json
@@ -3,5 +3,8 @@
   "create_armorer.attachment.extended_mag_ca_2.name": "Copper Plated Magazine",
   "create_armorer.attachment.extended_mag_ca_3.name": "Brass Plated Magazine",
 
-  "create_armorer.ammo.rbapb.name": "Rimmed Blunt Ammo"
+  "create_armorer.ammo.rbapb.name": "Rimmed Blunt Ammo",
+
+  "create_armorer.gun.mg_platemag_flywheel": "\"Flywheel\" Machine Gun",
+  "create_armorer.gun.rifle_assult_crane": "\"Crane\" Assault Rifle"
 }


### PR DESCRIPTION
Not much to say here, just some changes in the en_us.json files of both Create: Armorer and Applied Armorer.

- Fixed 4 typos
- Unified the names of 9 attachments
- Changed one gun's description to sound less awkward

My discord username is Jane2187 for that blue role.