### PR TITLE
Fix Ru translation of AE2

### DIFF
--- a/LanguageMerger/LanguageFiles/ae2/ru_ru/lang.json
+++ b/LanguageMerger/LanguageFiles/ae2/ru_ru/lang.json
@@ -2,5 +2,11 @@
     "gui.ae2.inWorldCraftingPresses": "Crafting Presses are obtained by breaking a Mysterious Cube. Mysterious Cubes are in the center of meteorites which can be found on the moon.",
     "__comment1": "Used in the Programmed Circuit Card, without doing this, the tooltip just shows the lang IDs",
     "gui.advanced_ae.AdvPatternProvider": "",
-    "gui.expandedae.exp_pattern_provider": ""
+    "gui.expandedae.exp_pattern_provider": "",
+    "item.ae2.portable_item_cell_256k": "256К Переносная предметная ячейка", 
+    "item.ae2.portable_fluid_cell_256k": "256К Переносная жидкостная ячейка", 
+    "item.ae2.cell_component_256k": "256К МЭ компонент хранения", 
+    "item.ae2.item_storage_cell_256k": "256К МЭ предметная ячейка хранения", 
+    "item.ae2.fluid_storage_cell_256k": "256К МЭ жидкостная ячейка хранения",
+    "block.ae2.256k_crafting_storage": "Хранилище для изготовления на 256К"  
 }


### PR DESCRIPTION
Somewhy default translation have all 256k things named "..16k.." so 16k and 256k things had same name.