### PR TITLE
Fix missing "Small" prefix for small_iron_gear

### DIFF
--- a/LanguageMerger/LanguageFiles/gtceu/en_us/items.json
+++ b/LanguageMerger/LanguageFiles/gtceu/en_us/items.json
@@ -23,7 +23,7 @@
 	"item.gtceu.tiny_netherrack_dust": "Tiny Pile of Keratophyre Dust",
 
 	"item.gtceu.iron_ring": "Cast Iron Ring",
-	"item.gtceu.small_iron_gear": "Cast Iron Gear",
+	"item.gtceu.small_iron_gear": "Small Cast Iron Gear",
 	"item.gtceu.iron_gear": "Cast Iron Gear",
 	"item.gtceu.iron_plate": "Cast Iron Plate",
 	"item.gtceu.double_iron_plate": "Double Cast Iron Plate",


### PR DESCRIPTION
## What is the new behavior?
Fix missing "Small" prefix for small_iron_gear