### PR TITLE
Update steam bloomery quest description 1/2

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/steam_age.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/steam_age.json
@@ -117,7 +117,8 @@
 
 	"quests.steam_age.steam_bloomery.title": "Steam Bloomery",
 	"quests.steam_age.steam_bloomery.subtitle": "The Bloomery's uncle",
-	"quests.steam_age.steam_bloomery.desc": "You're always going to need a lot of Wrought Iron, so why not automate your Bloomery? The next closest way to automate wrought iron is way off in LV.\n\nThe &3Steam Bloomery&r is a new multiblock that'll automate your old TFC bloomery, and do it faster too!\n\nLike with the Coke Oven, you can press the JEI 'Uses' key (defaults to \"U\") to show the multiblock preview tab. Click on individual blocks to see what's valid in each location.",
+	"quests.steam_age.steam_bloomery.desc.1": "You're always going to need a lot of Wrought Iron, so why not automate your Bloomery? The next closest way to automate wrought iron is way off in LV.\n\nThe &3Steam Bloomery&r is a new multiblock that'll automate your old TFC bloomery, and do it faster too!\n\nLike with the Coke Oven, you can press the JEI 'Uses' key (defaults to \"U\") to show the multiblock preview tab. Click on individual blocks to see what's valid in each location.",
+  	"quests.steam_age.steam_bloomery.desc.2": "The recipes actually take 50%% longer than what you'll find in JEI, due to how steam multiblocks work in gregtech.",
 
 	"quests.steam_age.steam_furnace.title": "Steam Furnace",
 	"quests.steam_age.steam_furnace.subtitle": "The Steam Furnace furnaces...",


### PR DESCRIPTION
## What is the new behavior?
-Clarified steam bloomery repice time inconsistency between JEI and in action within steam bloomery quest.

## Implementation Details
-added page to steam bloomery quest and description of the clarification on second page.

-Tldr:steam bloomery shows differend time in JEI than when used in world cause like most other steam multiblocks its 50% slower  but no where it is mentioned and it cannot be directly deduced as steam bloomery JEI shows only steam bloomery as valid blocks to craft steam bloomery repicies

-alternatives: clarification can be done without adding page, but it would also make steam bloomery description longest single page description within steam age. alternatively standardization between the JEI repice time within in action repice time of steam bloomery would resolve the inconsistency (over my skill level). or none.

## Outcome
-added extra information to steam bloomery description

## Additional Information
-

## Potential Compatibility Issues
most likely none unless weve fucked up somehow

Enter your Discord nickname, if your PR is successfully accepted, you will be given the Contributor role
seele_ (though i feel like its fairly inconsequential change to deserve contributor + got some from help from x.kato)