### PR TITLE
Fix liquefaction tower coil tooltip

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/en_us/tooltips.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/tooltips.json
@@ -76,7 +76,7 @@
     "tfg.tooltip.machine.two_energy_hatches": "Accepts up to §6Two§r Energy Hatches.",
     "tfg.tooltip.machine.subtick": "This machine supports §2Subticking§r!",
     "tfg.tooltip.machine.coil_energy_discount": "Every coil after §6Cupronickel§r reduces energy usage by 10%.",
-    "tfg.tooltip.machine.coil_speed_discount": "§6Cupronickel§r coils process 75% slower. Every coil after §3Kanthal§r increases processing speed by 50%.",
+    "tfg.tooltip.machine.coil_speed_discount": "§6Cupronickel§r coils process 25% slower. Every coil after §3Kanthal§r increases processing speed by 50%.",
     "tfg.tooltip.machine.bioreactor_1": "§7Chemistry meets Biology§r",
     "tfg.tooltip.machine.bioreactor_2": "§7Combines organic and inorganic ingredients to produce synthetic biological products.§r",
     "tfg.tooltip.machine.growth_chamber_1": "§7Growing new life§r",


### PR DESCRIPTION
## What is the new behavior?
The liquefaction tower currently says "Cupronickel coils process 75% slower", which is incorrect. It processes at the same speed as a pyrolyze oven with cupronickel coils which is 25% slower.

<img width="1506" height="376" alt="image" src="https://github.com/user-attachments/assets/128a8534-15cd-4fc7-8717-43f41d034edd" />
<img width="1409" height="307" alt="image" src="https://github.com/user-attachments/assets/521e955c-7f11-4954-aaee-98251e77f389" />
