### PR TITLE
fix spelling mistake in metal age

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/metal_age.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/metal_age.json
@@ -188,5 +188,5 @@
 
     "quests.metal_age.crafting_station.title": "Crafting Station",
     "quests.metal_age.crafting_station.subtitle": "Make that wall of chests useful!",
-    "quests.metal_age.crafting_station.desc": "You've given your Workbench legs! Now it can help you with your growing storage problem.\n\nPlace it nest to a series of chests, crates, or other containers, and you'll be able to see all of their contents at once inside the Crafting Station.\n\nWhat's more, it'll automatically pull from all of these inventories when crafting via JEI.\n\nIt can also hold your tools for you, even when exiting the GUI!"
+    "quests.metal_age.crafting_station.desc": "You've given your Workbench legs! Now it can help you with your growing storage problem.\n\nPlace it next to a series of chests, crates, or other containers, and you'll be able to see all of their contents at once inside the Crafting Station.\n\nWhat's more, it'll automatically pull from all of these inventories when crafting via JEI.\n\nIt can also hold your tools for you, even when exiting the GUI!"
 }


### PR DESCRIPTION
Fixes a small spelling mistake: nest -> next

Discord: noofwitloof

This is my first ever open source contribution. Starting small.