### PR TITLE
(bug) Typo fix for the word "creosote" in a translation key

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/tfg_tips.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/tfg_tips.json
@@ -218,7 +218,7 @@
     "quests.tfg_tips.creosote.title": "Lamp Fuel: Weak Fuels",
     "quests.tfg_tips.creosote.subtitle": "If you have a bunch of it lying around...",
     "quests.tfg_tips.creosote.desc": "&dCreosote&r and &dGregTech Oils&r can be used as a lamp fuel, but a full lamp of the stuff only lasts for &c10&r days.",
-    "quests.tfg_tips.creosote.task_croesote": "A Bucket of Creosote",
+    "quests.tfg_tips.creosote.task_creosote": "A Bucket of Creosote",
     "quests.tfg_tips.creosote.task_oil": "A Bucket of Oil",
     "quests.tfg_tips.creosote.task_light_oil": "A Bucket of Light Oil",
     "quests.tfg_tips.creosote.task_raw_oil": "A Bucket of Raw Oil",


### PR DESCRIPTION
## What is the new behavior?

The word "creosote" was misspelled as "croesote", causing the translation to not show up in the game and the game to instead use the raw translation key that was being expected.

## Outcome

The translation now shows correctly.

## Additional Information

**Behaviour Before**

<img width="832" height="475" alt="image" src="https://github.com/user-attachments/assets/6b54a01b-c22e-442d-a21a-d65f8c7c3cbd" />

**Behaviour After**

<img width="658" height="456" alt="image" src="https://github.com/user-attachments/assets/adbc7d4f-f0cd-44ae-bfa7-e95bb4203bbb" />

Moved this over to this repository on the request of @Redeix from TerraFirmaGreg-Team/Modpack-Modern#4509.

Apologies for the extra PR noise. I am still learning this project's structure.