### PR TITLE
Slime to Jellie Migration (Lang)

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/en_us/entities.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/entities.json
@@ -24,8 +24,5 @@
 	"entity.tfg.lemming": "Lemming",
 	"entity.tfg.fox": "Fox",
 	"entity.tfg.fox.female": "Vixen",
-	"entity.tfg.fox.male": "Fox",
-	"entity.tfg.slime": "Slime",
-	"entity.tfg.slime.female": "Slime",
-	"entity.tfg.slime.male": "Slime"
+	"entity.tfg.fox.male": "Fox"
 }

--- a/LanguageMerger/LanguageFiles/tfg/en_us/items.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/items.json
@@ -221,7 +221,6 @@
     "item.tfg.spawn_egg.lemming": "Lemming Spawn Egg",
     "item.tfg.spawn_egg.bison": "Bison Spawn Egg",
     "item.tfg.spawn_egg.leopard_seal": "Leopard Seal Spawn Egg",
-    "item.tfg.spawn_egg.slime": "Tameable Slime Spawn Egg",
 
     "item.tfg.flintlock_mechanism": "Flintlock Mechanism",
     "item.tfg.advanced_clockwork_mechanism": "Advanced Clockwork Mechanism",
@@ -543,10 +542,6 @@
     "item.tfg.parasiticide_capsule": "Parasiticide Capsule",
     "item.tfg.detox_capsule": "Detox Capsule",
     "item.tfg.nanofiltration_capsule": "Nanofiltration Capsule",
-
-    "item.tfg.slime.slime_ball.plant": "Plant Slime Ball",
-    "item.tfg.slime.slime_ball.glowberry": "Glowberry Slime Ball",
-    "item.tfg.slime.slime_ball.latex": "Latex Slime Ball",
 
     "item.tfg.chameleon_spray_can": "Chameleon Spray Can",
     "item.tfg.prismatic_paint_bucket": "Prismatic Paint Bucket",

--- a/LanguageMerger/LanguageFiles/tfg/en_us/jade.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/jade.json
@@ -10,13 +10,5 @@
     "tfc.enum.tfcwolfvariant.woods": "Variant: Woods",
 
     "tfg.tooltip.tamed_fox.variant.red": "Variant: Red",
-    "tfg.tooltip.tamed_fox.variant.snow": "Variant: Snow",
-
-    "tfg.jade.product.slime": "Slime Ready!",
-    "tfg.tooltip.slime.variant.plant": "Variant: Plant",
-    "tfg.tooltip.slime.variant.glowberry": "Variant: Glowberry",
-    "tfg.tooltip.slime.variant.spring": "Variant: Spring",
-    "tfg.tooltip.slime.variant.ice": "Variant: Ice",
-    "tfg.tooltip.slime.variant.lava": "Variant: Lava",
-    "tfg.tooltip.slime.variant.latex": "Variant: Latex"
+    "tfg.tooltip.tamed_fox.variant.snow": "Variant: Snow"
 }


### PR DESCRIPTION
## What is the new behavior?
Removed slime lang because all of jellie lang is inside the Jellies mod.

## Companion PRs:
Core: https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/532
Modpack: https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/4546