### PR TITLE
Smithing template armor trims "Add ingot or crystal" -> "Add plate or exquisite gem" items.json

### DIFF
--- a/LanguageMerger/LanguageFiles/minecraft/en_us/items.json
+++ b/LanguageMerger/LanguageFiles/minecraft/en_us/items.json
@@ -9,5 +9,6 @@
 	"item.minecraft.nether_brick": "Keratophyre Brick",
 	"item.minecraft.furnace_minecart": "Minecart with Boiler",
 	"item.minecraft.milk_bucket": "Cow Milk Bucket",
+	"item.minecraft.smithing_template.armor_trim.additions_slot_description": "Add plate or exquisite gem",
 	"item.minecraft.quartz": "Smoky Quartz"
 }


### PR DESCRIPTION



## What is the new behavior?
Smithing table lang updated to match TFG's recipe changes
