### PR TITLE
task.[tasknumber] uniformation

### DIFF
--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/combat_tips.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/combat_tips.json
@@ -41,14 +41,14 @@
 	"quests.combat_tips.mold_weapons.title": "Molded Weapons",
 	"quests.combat_tips.mold_weapons.subtitle": "The power of metal",
 	"quests.combat_tips.mold_weapons.description": "Molds allow you to make copper and bronze versions of all weapons, including three new types: Swords, Scythes, and Maces. \n\nSwords: These well rounded weapons deal &6Slashing&r damage. \n\nScythes: They do more damage than swords, but are slower. They deal &6Slashing&r damage. \n\nMaces: They are the best weapons that deal &2Crushing&r damage.",
-	"quests.combat_tips.mold_weapons.task1": "Any Sword",
-	"quests.combat_tips.mold_weapons.task2": "Any Scythe",
-	"quests.combat_tips.mold_weapons.task3": "Any Mace",
+	"quests.combat_tips.mold_weapons.task.1": "Any Sword",
+	"quests.combat_tips.mold_weapons.task.2": "Any Scythe",
+	"quests.combat_tips.mold_weapons.task.3": "Any Mace",
 
 	"quests.combat_tips.bow.title": "Bow and Arrow",
 	"quests.combat_tips.bow.subtitle": "Then I took an arrow to the knee...",
 	"quests.combat_tips.bow.description": "While javelins are cool, it's hard to beat a bow and arrow. Arrows can be expensive, so setting up a bird farm isn't a bad idea. Arrows deal &9Piercing&r damage. \n\nOnce you have leather you will be able to craft a &5Quiver&r which allows you to have easy access to up to 8 stacks of arrows!",
-	"quests.combat_tips.bow.task2": "Any Arrow",
+	"quests.combat_tips.bow.task.2": "Any Arrow",
 
 	"quests.combat_tips.bronze_main.title": "Bronze Age",
 
@@ -65,10 +65,10 @@
 	"quests.combat_tips.armor.title": "Metal Armor",
 	"quests.combat_tips.armor.subtitle": "Only the shiniest suit of armor",
 	"quests.combat_tips.armor.description": "Metal armor requires a two-step forging process, but don't be scared off by its difficulty. Metal armor will boost your survival chances going into the &dBeneath&r or if you fight off a group of &3Illagers&r.\n\nAll metal armor will give you bonus protection to &6Slashing&r, &9Piercing&r, and &2Crushing&r damage",
-	"quests.combat_tips.armor.task1": "Any Metal Helmet",
-	"quests.combat_tips.armor.task2": "Any Metal Chestplate",
-	"quests.combat_tips.armor.task3": "Any Metal Greaves",
-	"quests.combat_tips.armor.task4": "Any Metal Boots",
+	"quests.combat_tips.armor.task.1": "Any Metal Helmet",
+	"quests.combat_tips.armor.task.2": "Any Metal Chestplate",
+	"quests.combat_tips.armor.task.3": "Any Metal Greaves",
+	"quests.combat_tips.armor.task.4": "Any Metal Boots",
 
 	"quests.combat_tips.iron_main.title": "Iron Age",
 

--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/high_voltage.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/high_voltage.json
@@ -224,8 +224,8 @@
 
     "quests.high_voltage.gun.title": "Bring a gun",
     "quests.high_voltage.gun.subtitle": "And if that don't work, use more gun",
-    "quests.high_voltage.gun.task1": "Any gun",
-    "quests.high_voltage.gun.task2": "Any medicine or aged alcohol",
+    "quests.high_voltage.gun.task.1": "Any gun",
+    "quests.high_voltage.gun.task.2": "Any medicine or aged alcohol",
     "quests.high_voltage.gun.desc": "Getting a little too comfortable on Earth? You won't be alone on the moon, so make sure you're well prepared to defend yourself - you'll need more than just a sword or some stone javelins.\n\n&4The Moon is dangerous&r and you wouldn't want to lose your precious Rocket right?\n\nPick out a nice gun (if you're not sure, we recommend the &o\"Clockwork\" Rifle&r), craft some ammo, and maybe try out some attachments if you're feeling fancy.\n\nIt's also a good idea to bring some nutritious food to raise your max HP (try the meal bags!) as well as some alcohol and medicine for buffs and healing.",
 
     "quests.high_voltage.space_survival.title": "Home away from home",

--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/metal_age.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/metal_age.json
@@ -121,9 +121,9 @@
     "quests.metal_age.weak_steel.title": "Weak Steel Ingredients",
     "quests.metal_age.weak_steel.subtitle": "Hope you like math",
     "quests.metal_age.weak_steel.desc": "Weak Steel is one part of the necessary metals to create Black Steel. You can alloy it with 2 parts Steel, 1 part Nickel and 1 part Black Bronze.\n\nYou can check the liquid weak steel's recipe for more precise alloying percentage rates.",
-    "quests.metal_age.weak_steel.task1": "1 Part Nickel",
-    "quests.metal_age.weak_steel.task2": "2 Parts Steel",
-    "quests.metal_age.weak_steel.task3": "1 Part Black Bronze",
+    "quests.metal_age.weak_steel.task.1": "1 Part Nickel",
+    "quests.metal_age.weak_steel.task.2": "2 Parts Steel",
+    "quests.metal_age.weak_steel.task.3": "1 Part Black Bronze",
 
     "quests.metal_age.highcarb_black_steel.title": "Black Steel Ingredients",
     "quests.metal_age.highcarb_black_steel.subtitle": "Conservation of matter does not apply",

--- a/LanguageMerger/LanguageFiles/tfg/en_us/Quests/tfg_tips.json
+++ b/LanguageMerger/LanguageFiles/tfg/en_us/Quests/tfg_tips.json
@@ -973,8 +973,8 @@
 
     "quests.tfg_tips.tools_tips.mattocks.title": "Mattocks",
     "quests.tfg_tips.tools_tips.mattocks.subtitle": "A shovel just wont do.",
-    "quests.tfg_tips.tools_tips.mattocks.task0": "Any Mattock",
-    "quests.tfg_tips.tools_tips.mattocks.task1": "Any Road Material",
+    "quests.tfg_tips.tools_tips.mattocks.task.0": "Any Mattock",
+    "quests.tfg_tips.tools_tips.mattocks.task.1": "Any Road Material",
     "quests.tfg_tips.tools_tips.mattocks.desc": "&cMattocks&r are your key to developing roads in TFG. They can be acquired through casting into a mold like any other TFC tool. To use a mattock change its mode (default-key: &3&lN&r&r) to \"full-block\". \nThen you can right-click on dirt or grass to tamp it down. You can then apply &6crushed base course&r and finally the material of your choice after.",
 
     "quests.tfg_tips.tools_tips.base_course.title": "Base Course",


### PR DESCRIPTION
## What is the new behavior?
Uniforming language files to use only 'task.[tasknumber]' form, instead of 'task[tasknumber]' and 'task.[tasknumber]'

## Implementation Details
Simple sed operation

discord: dxthwsh